### PR TITLE
Ensure that all layers that should be deleted are

### DIFF
--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -57,7 +57,7 @@
   $: actualMaxZoom = maxzoom ?? $maxZoomContext;
 
   onDestroy(() => {
-    if ($layer && $map?.loaded()) {
+    if ($layer && $map) {
       $map?.removeLayer($layer);
     }
   });


### PR DESCRIPTION
`$map?.loaded()` will return `false` if  "there has been a change to the sources or style that has not yet fully loaded". This means that in cases where several layers should be deleted at once, only the first one will be.

## Reproducing the bug

The cluster example has a `<GeoJSON>` component, with a `<CircleLayer>`, `<SymbolLayer>` and `CircleLayer` as children.

Suppose that we allow the user to toggle whether or not they are displayed by wrapping the children in a `{#if showMarkers}` directive (with the value of `showMarkers` bound to a UI element).

When the condition because `false`, the `onDestroy` lifecycle method is called for each of the `SymbolLayer`/`CircleLayer`s, but after the first method calls `$map.removeLayer()`, `$map.loaded()` becomes `false` and so the other layes are not removed:

With `showMarkers` true:

![all-markers-visible](https://user-images.githubusercontent.com/338833/233413100-1fd635ce-7789-4473-8582-a8bea4c2a240.png)

After `showMarkers` becomes false, some markers remain:

![some-markers-remaining](https://user-images.githubusercontent.com/338833/233413128-84a2ff6e-13bd-40ef-be53-1f037612d0f9.png)

But the map should look like this:

![expected](https://user-images.githubusercontent.com/338833/233414625-4c85f5f4-ede9-4717-92cb-649083c280b2.png)


Modified version of `routes/clusters/+page.svelete` (with extension changed to allow upload):
[modified_+page.svelte.TXT](https://github.com/dimfeld/svelte-maplibre/files/11287895/modified_%2Bpage.svelte.TXT)
