### PR TITLE
Add transformRequest prop to MapLibre component

### DIFF
--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -37,6 +37,9 @@
   export let filterLayers: ((layer: maplibregl.LayerSpecification) => boolean) | undefined =
     undefined;
 
+  /** Function that modifies requests, such as by adding an API key. **/
+  export let transformRequest: maplibregl.RequestTransformFunction | undefined = undefined;
+
   $: standardControlsPosition =
     typeof standardControls === 'boolean' ? undefined : standardControls;
 
@@ -104,6 +107,7 @@
       maxBounds,
       bounds,
       attributionControl,
+      transformRequest
     });
 
     $mapInstance.on('load', (e) => {


### PR DESCRIPTION
The transformRequest [option to `maplibregl.Map`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map-parameters) is very useful in specifying how an API key should be added to requests.