### PR TITLE
Fix hover state for features with ID 0

### DIFF
--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -147,7 +147,7 @@
       let featureId = features[0]?.id;
       if (featureId !== hoverFeatureId) {
         if (manageHoverState) {
-          if (hoverFeatureId) {
+          if (hoverFeatureId !== undefined) {
             $map?.setFeatureState({ source: actualSource!, id: hoverFeatureId }, { hover: false });
           }
 
@@ -178,7 +178,7 @@
       }
 
       hovered = null;
-      if (manageHoverState && hoverFeatureId) {
+      if (manageHoverState && hoverFeatureId !== undefined) {
         $map?.setFeatureState({ source: actualSource!, id: hoverFeatureId }, { hover: false });
         hoverFeatureId = undefined;
       }


### PR DESCRIPTION
0 is a valid feature ID, but because it's falsy, it's often a headache. I noticed hover state for such cases gets stuck: hovering on the feature works, but then moving off doesn't change anything. This PR should fix that.

I tested over in https://github.com/dabreegster/geodiffr, but if there's another approach to testing in the built-in app here, let me know