### PR TITLE
Support 2-way binding on Marker position when dragging

### DIFF
--- a/src/routes/examples/draggable_custom_marker/+page.svelte
+++ b/src/routes/examples/draggable_custom_marker/+page.svelte
@@ -8,11 +8,14 @@
 
   let markerPos = [-122.2993, 47.4464];
   const handleDrag = (event: CustomEvent<MarkerClickInfo>) => (markerPos = event.detail.lngLat);
+
+  let boundPos = { lng: -10, lat: -20 };
 </script>
 
-<p>
-  Current position: {JSON.stringify(markerPos)}
-</p>
+<ul>
+  <li>Position from drag events: {JSON.stringify(markerPos)}</li>
+  <li>Position from <code>bind:latLng</code>: {JSON.stringify(boundPos)}</li>
+</ul>
 
 <MapLibre
   style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
@@ -29,6 +32,19 @@
   >
     <span> Drag me ! </span>
   </Marker>
+
+  <Marker
+    bind:lngLat={boundPos}
+    draggable
+    class="border-gray-200 border shadow-2xl focus:outline-2 focus:outline-black w-24 h-8 bg-red-300 text-black rounded-full grid place-items-center"
+  >
+    <span> 2-way Bound ! </span>
+  </Marker>
 </MapLibre>
+
+<p>
+  Bound props can use either <code>&#123; lng, lat &#125;</code> objects or GeoJSON Location
+  <code>[lng, lat]</code> arrays.
+</p>
 
 <CodeSample {code} />


### PR DESCRIPTION
This allows you to use `bind:lngLat` on a draggable `Marker` to propagate position updates through the prop as it drags.

Resolves #47 