### PR TITLE
Persist sources and layers when basemap style changes

### DIFF
--- a/.changeset/neat-horses-rule.md
+++ b/.changeset/neat-horses-rule.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Preserve sources and layers added by the user when changing the base map style

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -173,7 +173,7 @@
         }
         if (layersToReAddAfterStyleChange) {
           for (const layer of layersToReAddAfterStyleChange) {
-            $mapInstance?.addLayer(layer);
+            $mapInstance.addLayer(layer);
           }
         }
       }

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { createMapContext } from './context.js';
-  import maplibre, { type LngLatBoundsLike, type LngLatLike } from 'maplibre-gl';
+  import maplibre, {
+    type LayerSpecification,
+    type LngLatBoundsLike,
+    type LngLatLike,
+    type SourceSpecification,
+  } from 'maplibre-gl';
   import compare from 'just-compare';
   import 'maplibre-gl/dist/maplibre-gl.css';
   import type { CustomImageSpec } from './types.js';
@@ -97,6 +102,17 @@
 
   $: allImagesLoaded = images.every((image) => $loadedImages.has(image.id));
 
+  // These variables are used to keep track of what sources / layers
+  // are part of the basemap style vs those that are part of the
+  // user defined sources and layers. This is so we can reconstruct the
+  // user defined sources and layers after a basemap style change which
+  // overwrites all previous sources and layers
+
+  let lastStyleLayerIds: Array<string> | undefined = undefined;
+  let lastStyleSourceIds: Array<string> | undefined = undefined;
+  let layersToReAddAfterStyleChange: Array<LayerSpecification> | undefined = undefined;
+  let sourcesToReAddAfterStyleChange: Record<string, SourceSpecification> | undefined = undefined;
+
   function createMap(element: HTMLDivElement) {
     $mapInstance = new maplibre.Map({
       container: element,
@@ -140,6 +156,29 @@
       dispatch('zoomend', { ...ev, map: $mapInstance });
     });
 
+    // When the basemap style is changed, it nukes all existing layers and sources
+    // Here we listen for style.load events, store the layers and sources that
+    // have come from the new basemap style and then add back in any layers and
+    // styles that where added by the user as sub elements
+
+    $mapInstance.on('style.load', () => {
+      if ($mapInstance) {
+        const mapStyle = $mapInstance.getStyle();
+        lastStyleLayerIds = mapStyle.layers.map((l) => l.id);
+        lastStyleSourceIds = Object.keys(mapStyle.sources);
+        if (sourcesToReAddAfterStyleChange) {
+          for (const [id, source] of Object.entries(sourcesToReAddAfterStyleChange)) {
+            $mapInstance.addSource(id, source);
+          }
+        }
+        if (layersToReAddAfterStyleChange) {
+          for (const layer of layersToReAddAfterStyleChange) {
+            $mapInstance?.addLayer(layer);
+          }
+        }
+      }
+    });
+
     $mapInstance.on('styledata', (ev) => {
       if ($mapInstance && filterLayers) {
         const layers = $mapInstance.getStyle().layers;
@@ -165,7 +204,33 @@
   }
 
   let lastStyle = style;
+
+  // If the last style is different from the current one
+  // we grab a list of the currrent layers and sources
+  // compare this with the stored list of layer and source ids
+  // to pick out the layers / sources which are not part of the current
+  // basemaps.
+  // We then update the style which will trigger the style.load event on
+  // map which will in turn add the user defined sources and layers back
+  // on to the map
+
   $: if ($mapInstance && !compare(style, lastStyle)) {
+    const oldMapStyle = $mapInstance.getStyle();
+
+    if (lastStyleLayerIds) {
+      layersToReAddAfterStyleChange = oldMapStyle.layers.filter(
+        (l) => !lastStyleLayerIds!.includes(l.id)
+      );
+    }
+    if (lastStyleSourceIds) {
+      const nonStyleSourceIds = Object.keys(oldMapStyle.sources).filter(
+        (sourceId) => !lastStyleSourceIds!.includes(sourceId)
+      );
+      sourcesToReAddAfterStyleChange = {};
+      for (const id of nonStyleSourceIds) {
+        sourcesToReAddAfterStyleChange[id] = oldMapStyle.sources[id];
+      }
+    }
     lastStyle = style;
     $mapInstance.setStyle(style, { diff: diffStyleUpdates });
   }

--- a/src/routes/NavBar.svelte
+++ b/src/routes/NavBar.svelte
@@ -27,6 +27,7 @@
     { href: '/examples/zoom_transition', title: `Transition Layers with Zoom` },
     { href: '/examples/overlapping_layer_events', title: `Overlapping Layer Events` },
     { href: '/examples/deckgl-arcs', title: `Deck.gl Arc Layers` },
+    { href: '/examples/changing_basemap_style', title: `Changing basemap style` },
   ];
 
   // Examples which don't really warrant showing on the docs site, but ensure that

--- a/src/routes/examples/changing_basemap_style/+page.svelte
+++ b/src/routes/examples/changing_basemap_style/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import MapLibre from '$lib/MapLibre.svelte';
+  import GeoJSON from '$lib/GeoJSON.svelte';
+  import FillLayer from '$lib/FillLayer.svelte';
+  import LineLayer from '$lib/LineLayer.svelte';
+  import { mapClasses } from '../styles.js';
+  import code from './+page.svelte?raw';
+  import CodeSample from '$site/CodeSample.svelte';
+  import states from '$site/states.json?url';
+  import { hoverStateFilter } from '$lib/filters.js';
+
+  let showBorder = true;
+  let showFill = true;
+  let fillColor = '#006600';
+  let borderColor = '#003300';
+  let selected: 'light' | 'dark' = 'light';
+  $: style =
+    selected === 'light'
+      ? 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'
+      : 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+
+  console.log('selected ', selected, ' style ', style);
+</script>
+
+<select class="basemap-select" bind:value={selected}>
+  <option value="light">Light</option>
+  <option value="dark">dark</option>
+</select>
+
+<MapLibre {style} class={mapClasses} standardControls center={[-98.137, 40.137]} zoom={4}>
+  <GeoJSON id="states" data={states} promoteId="STATEFP">
+    {#if showFill}
+      <FillLayer
+        paint={{
+          'fill-color': fillColor,
+          'fill-opacity': 0.5,
+        }}
+        beforeLayerType="symbol"
+      />
+    {/if}
+    {#if showBorder}
+      <LineLayer
+        layout={{ 'line-cap': 'round', 'line-join': 'round' }}
+        paint={{ 'line-color': borderColor, 'line-width': 3 }}
+        beforeLayerType="symbol"
+      />
+    {/if}
+  </GeoJSON>
+</MapLibre>
+
+<CodeSample {code} />
+
+<style>
+  .grid {
+    grid-template-columns: repeat(auto-fill, 150px);
+  }
+  .basemap-select {
+    box-sizing: border-box;
+    padding: 10px 20px;
+  }
+</style>

--- a/src/routes/examples/changing_basemap_style/+page.ts
+++ b/src/routes/examples/changing_basemap_style/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = () => {
+  return {
+    title: 'Changing the basemap style',
+  };
+}


### PR DESCRIPTION
This PR fixes a bug where user defined layers and sources got overwritten when the basemap styleURL changed.

To fix this I added some extra logic to the MapLibre component that

1. When the map style loads, we take note of what layers and sources it defines.
2. When the style parameter changes, we compare the current list of sources and layers on the map to the ones on the old basemap style and take note of any which are not part of the old basemap style
3. Then when the new style loads, we reload each of the sources and layers that got deleted.

I also added an example page which shows this in effect, mostly for testing.

Would be great to get a few eyes on this PR as the logic is a bit complex and I want to make sure this doesn't have any unintended consequences or side effects