### PR TITLE
Make manageHoverState consistent. #35

### DIFF
--- a/src/lib/CircleLayer.svelte
+++ b/src/lib/CircleLayer.svelte
@@ -24,6 +24,7 @@
   export let maxzoom: number | undefined = undefined;
   /** Set the cursor style to this value when the mouse is over the layer. */
   export let hoverCursor: string | undefined = undefined;
+  export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
 </script>
@@ -42,6 +43,7 @@
   {minzoom}
   {maxzoom}
   {hoverCursor}
+  {manageHoverState}
   {eventsIfTopMost}
   bind:hovered
   on:click

--- a/src/lib/FillExtrusionLayer.svelte
+++ b/src/lib/FillExtrusionLayer.svelte
@@ -23,6 +23,7 @@
   export let maxzoom: number | undefined = undefined;
   /** Set the cursor style to this value when the mouse is over the layer. */
   export let hoverCursor: string | undefined = undefined;
+  export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
 </script>
@@ -40,6 +41,7 @@
   {minzoom}
   {maxzoom}
   {hoverCursor}
+  {manageHoverState}
   {eventsIfTopMost}
   bind:hovered
   on:click

--- a/src/lib/FillLayer.svelte
+++ b/src/lib/FillLayer.svelte
@@ -23,6 +23,7 @@
   export let maxzoom: number | undefined = undefined;
   /** Set the cursor style to this value when the mouse is over the layer. */
   export let hoverCursor: string | undefined = undefined;
+  export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
 </script>
@@ -40,6 +41,7 @@
   {minzoom}
   {maxzoom}
   {hoverCursor}
+  {manageHoverState}
   {eventsIfTopMost}
   bind:hovered
   on:click

--- a/src/lib/HeatmapLayer.svelte
+++ b/src/lib/HeatmapLayer.svelte
@@ -23,6 +23,7 @@
   export let maxzoom: number | undefined = undefined;
   /** Set the cursor style to this value when the mouse is over the layer. */
   export let hoverCursor: string | undefined = undefined;
+  export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
 </script>
@@ -40,6 +41,7 @@
   {minzoom}
   {maxzoom}
   {hoverCursor}
+  {manageHoverState}
   {eventsIfTopMost}
   bind:hovered
   on:click

--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -30,7 +30,8 @@
   export let applyToClusters: boolean | undefined = undefined;
   export let minzoom: number | undefined = undefined;
   export let maxzoom: number | undefined = undefined;
-  export let manageHoverState = true;
+  /** Enable to use hoverStateFilter. */
+  export let manageHoverState = false;
   /** The feature currently being hovered. */
   export let hovered: GeoJSON.Feature | null = null;
 

--- a/src/lib/SymbolLayer.svelte
+++ b/src/lib/SymbolLayer.svelte
@@ -24,6 +24,7 @@
   export let maxzoom: number | undefined = undefined;
   /** Set the cursor style to this value when the mouse is over the layer. */
   export let hoverCursor: string | undefined = undefined;
+  export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
 </script>
@@ -42,6 +43,7 @@
   {minzoom}
   {maxzoom}
   {hoverCursor}
+  {manageHoverState}
   {eventsIfTopMost}
   bind:hovered
   on:click

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -41,7 +41,7 @@ export function isClusterFilter(
     : undefined;
 }
 
-/** Return an expression that returns a value based on whether the feature is hovered. */
+/** Return an expression that returns a value based on whether the feature is hovered. Requires manageHoverState to be enabled for the layer. */
 export function hoverStateFilter(
   defaultValue: string | number | boolean,
   hoverValue: string | number | boolean

--- a/src/routes/examples/clusters/+page.svelte
+++ b/src/routes/examples/clusters/+page.svelte
@@ -67,6 +67,7 @@
         'circle-stroke-width': 1,
         'circle-stroke-opacity': hoverStateFilter(0, 1),
       }}
+      manageHoverState
       on:click={(e) => (clickedFeature = e.detail.features?.[0]?.properties)}
     >
       <Popup {openOn} closeOnClickInside let:features>

--- a/src/routes/examples/custom_marker_clusters/+page.svelte
+++ b/src/routes/examples/custom_marker_clusters/+page.svelte
@@ -6,7 +6,6 @@
   import { mapClasses } from '../styles';
   import CircleLayer from '$lib/CircleLayer.svelte';
   import SymbolLayer from '$lib/SymbolLayer.svelte';
-  import { hoverStateFilter } from '$lib/filters';
   import Popup from '$lib/Popup.svelte';
   import ClusterPopup from '../ClusterPopup.svelte';
   import clusterPopupCode from '../ClusterPopup.svelte?raw';

--- a/src/routes/examples/deckgl-arcs/+page.svelte
+++ b/src/routes/examples/deckgl-arcs/+page.svelte
@@ -87,6 +87,7 @@
         'fill-color': '#000',
         'fill-opacity': mode === 'showOne' ? hoverStateFilter(0, 0.1) : 0,
       }}
+      manageHoverState
       on:mousemove={(e) => {
         if (mode === 'showOne') {
           let newGeoId = e.detail.features[0]?.properties?.STATEFP;

--- a/src/routes/examples/geojson_polygon/+page.svelte
+++ b/src/routes/examples/geojson_polygon/+page.svelte
@@ -58,6 +58,7 @@
           'fill-opacity': 0.5,
         }}
         beforeLayerType="symbol"
+        manageHoverState
       />
     {/if}
     {#if showBorder}

--- a/src/routes/examples/image_symbols/+page.svelte
+++ b/src/routes/examples/image_symbols/+page.svelte
@@ -59,6 +59,7 @@
         'circle-stroke-width': 1,
         'circle-stroke-opacity': hoverStateFilter(0, 1),
       }}
+      manageHoverState
       on:click={(e) => (clickedFeature = e.detail.features?.[0]?.properties)}
     />
 


### PR DESCRIPTION
As described in #35, this disables `manageHoverState` by default and plumbs it through all layers. Unless I'm mistaken, it only affects `hoverStateFilter`. This is a breaking API change; anybody using `hoverStateFilter` on anything except line layers will need to enable this.