### PR TITLE
Adding prepare file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,15 +26,14 @@
     "build": "vite build && npm run package",
     "preview": "vite preview",
     "package": "svelte-kit sync && svelte-package && publint",
-    "prepublishOnly": "npm run package",
+    "prepare": "npm run package",
     "test": "playwright test",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test:unit": "vitest",
     "generate-changelog": "source ghtoken; GITHUB_TOKEN=${GITHUB_TOKEN} changeset version",
     "lint": "prettier --plugin-search-dir . --check src && eslint .",
-    "format": "prettier --plugin-search-dir . --write src",
-    "prepare":"npm build"
+    "format": "prettier --plugin-search-dir . --write src"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:unit": "vitest",
     "generate-changelog": "source ghtoken; GITHUB_TOKEN=${GITHUB_TOKEN} changeset version",
     "lint": "prettier --plugin-search-dir . --check src && eslint .",
-    "format": "prettier --plugin-search-dir . --write src"
+    "format": "prettier --plugin-search-dir . --write src",
+    "prepare":"npm build"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Adds a prepare script so that people can use a link to github for the project dependency as well as npm.

https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish