### PR TITLE
Adding missing top level export for VectorTileSource

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -16,6 +16,7 @@ export { default as MapLibre } from './MapLibre.svelte';
 export { default as Marker } from './Marker.svelte';
 export { default as MarkerLayer } from './MarkerLayer.svelte';
 export { default as NavigationControl } from './NavigationControl.svelte';
+export { default as VectorTileSource } from "./VectorTileSource.svelte"
 export { default as Popup } from './Popup.svelte';
 export { default as ScaleControl } from './ScaleControl.svelte';
 export { default as SymbolLayer } from './SymbolLayer.svelte';


### PR DESCRIPTION
I forgot to export the VectorTileSource at the top level of the lib in #59  