### PR TITLE
Make eventsIfTopMost also work for manageHoverState, and introduce

### DIFF
--- a/.changeset/bright-falcons-study.md
+++ b/.changeset/bright-falcons-study.md
@@ -1,6 +1,6 @@
 ---
-'svelte-maplibre': minor
+'svelte-maplibre': major
 ---
 
 Make eventsIfTopMost also work for manageHoverState, and introduce
-openIfTopMost for Popups.
+openIfTopMost for Popups. The default behavior for overlapping popups changes.

--- a/.changeset/bright-falcons-study.md
+++ b/.changeset/bright-falcons-study.md
@@ -1,0 +1,6 @@
+---
+'svelte-maplibre': minor
+---
+
+Make eventsIfTopMost also work for manageHoverState, and introduce
+openIfTopMost for Popups.

--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -173,6 +173,9 @@
         return;
       }
 
+      // This may get out of sync, if this layer regains focus from a higher layer.
+      $map.getCanvas().style.cursor = hoverCursor;
+
       let features = e.features ?? [];
 
       let clusterId = features[0]?.properties?.cluster_id;

--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -161,6 +161,15 @@
 
     $map.on('mousemove', $layer, (e) => {
       if (eventsIfTopMost && eventTopMost(e) !== $layer) {
+        hovered = null;
+        if (manageHoverState && hoverFeatureId !== undefined) {
+          $map?.setFeatureState(
+            { source: actualSource!, sourceLayer, id: hoverFeatureId },
+            { hover: false }
+          );
+          hoverFeatureId = undefined;
+        }
+
         return;
       }
 
@@ -210,7 +219,7 @@
       hovered = null;
       if (manageHoverState && hoverFeatureId !== undefined) {
         const featureSelector = { source: actualSource!, id: hoverFeatureId, sourceLayer };
-        $map?.setFeatureState(featureSelector, { hover: false })
+        $map?.setFeatureState(featureSelector, { hover: false });
         hoverFeatureId = undefined;
       }
 

--- a/src/lib/Popup.svelte
+++ b/src/lib/Popup.svelte
@@ -21,6 +21,8 @@
   /** Define when to open the popup. If set to manual, you can open the popup programmatically by
    * setting the `open` attribute. */
   export let openOn: 'hover' | 'click' | 'dblclick' | 'contextmenu' | 'manual' = 'click';
+  /** Only open the popup if there's no feature from a higher layer covering this one. */
+  export let openIfTopMost = false;
 
   export let focusAfterOpen = true;
   export let anchor: maplibregl.PositionAnchor | undefined = undefined;
@@ -38,7 +40,7 @@
   /** Whether the popup is open or not. Can be set to manualy open the popup at `lngLat`. */
   export let open = false;
 
-  const { map, popupTarget, layerEvent } = mapContext();
+  const { map, popupTarget, layerEvent, layer, eventTopMost } = mapContext();
 
   const clickEvents = ['click', 'dblclick', 'contextmenu'];
 
@@ -170,6 +172,10 @@
       return;
     }
 
+    if (openIfTopMost && eventTopMost(e) !== $layer) {
+      return;
+    }
+
     if ('layerType' in e) {
       if (e.layerType === 'deckgl') {
         lngLat = e.coordinate;
@@ -224,6 +230,12 @@
 
   function handleLayerMouseMove(e: MapLayerMouseEvent) {
     if (openOn !== 'hover' || touchStartCoords || touchOpenState !== 'normal') {
+      return;
+    }
+
+    if (openIfTopMost && eventTopMost(e) !== $layer) {
+      open = false;
+      features = null;
       return;
     }
 

--- a/src/lib/Popup.svelte
+++ b/src/lib/Popup.svelte
@@ -22,7 +22,7 @@
    * setting the `open` attribute. */
   export let openOn: 'hover' | 'click' | 'dblclick' | 'contextmenu' | 'manual' = 'click';
   /** Only open the popup if there's no feature from a higher layer covering this one. */
-  export let openIfTopMost = false;
+  export let openIfTopMost = true;
 
   export let focusAfterOpen = true;
   export let anchor: maplibregl.PositionAnchor | undefined = undefined;

--- a/src/routes/examples/geojson_line_layer/+page.svelte
+++ b/src/routes/examples/geojson_line_layer/+page.svelte
@@ -42,7 +42,9 @@
   };
 </script>
 
-<p>This example also uses the <code>hash</code> property to sync the map's location with the address bar.</p>
+<p>
+  This example also uses the <code>hash</code> property to sync the map's location with the address bar.
+</p>
 
 <MapLibre
   style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"

--- a/src/routes/examples/overlapping_layer_events/+page.svelte
+++ b/src/routes/examples/overlapping_layer_events/+page.svelte
@@ -52,31 +52,33 @@
   let openOn: 'click' | 'dblclick' | 'contextmenu' | 'hover' = 'hover';
 </script>
 
-<label>
-  <input type="checkbox" bind:checked={eventsIfTopMost} />
-  When layers overlap, only fire events for top-most layer
-</label>
+<div class="mx-auto mb-2 flex flex-col items-start gap-1">
+  <label>
+    <input type="checkbox" bind:checked={eventsIfTopMost} />
+    When layers overlap, only fire events for top-most layer
+  </label>
 
-<label>
-  <input type="checkbox" bind:checked={openIfTopMost} />
-  When layers overlap, only activate the popup for top-most layer
-</label>
+  <label>
+    <input type="checkbox" bind:checked={openIfTopMost} />
+    When layers overlap, only activate the popup for top-most layer
+  </label>
 
-<fieldset class="border border-gray-300 self-start px-2 flex gap-x-4 mb-2">
-  <legend>Show popup on</legend>
-  <label><input type="radio" bind:group={openOn} value="hover" /> Hover</label>
-  <label><input type="radio" bind:group={openOn} value="click" /> Click</label>
-  <label><input type="radio" bind:group={openOn} value="dblclick" /> Double Click</label>
-  <label
-    ><input type="radio" bind:group={openOn} value="contextmenu" /> Context Menu (right-click)</label
-  >
-</fieldset>
+  <fieldset class="flex gap-x-4">
+    <legend>Show popup on</legend>
+    <label><input type="radio" bind:group={openOn} value="hover" /> Hover</label>
+    <label><input type="radio" bind:group={openOn} value="click" /> Click</label>
+    <label><input type="radio" bind:group={openOn} value="dblclick" /> Double Click</label>
+    <label
+      ><input type="radio" bind:group={openOn} value="contextmenu" /> Context Menu (right-click)</label
+    >
+  </fieldset>
 
-<div class="grid grid-cols-[auto_1fr] gap-x-2">
-  {#each layers as layer, i}
-    <span class="flex-none">Last Event for {layer.color} layer: </span>
-    <span class="w-64">{labelFeature(lastEvent[i])}</span>
-  {/each}
+  <div class="grid grid-cols-[auto_1fr] gap-x-2">
+    {#each layers as layer, i}
+      <span class="flex-none">Last Event for {layer.color} layer: </span>
+      <span class="w-64">{labelFeature(lastEvent[i])}</span>
+    {/each}
+  </div>
 </div>
 
 <MapLibre

--- a/src/routes/examples/overlapping_layer_events/+page.svelte
+++ b/src/routes/examples/overlapping_layer_events/+page.svelte
@@ -32,9 +32,9 @@
   const layer3 = Array.from({ length: 20 }, randomCircle);
 
   const layers = [
-    { data: layer1, color: 'red' },
-    { data: layer2, color: 'green' },
-    { data: layer3, color: 'blue' },
+    { data: layer1, color: 'red', hoverCursor: 'help' },
+    { data: layer2, color: 'green', hoverCursor: '' },
+    { data: layer3, color: 'blue', hoverCursor: 'not-allowed' },
   ];
 
   const lastEvent = [];
@@ -86,11 +86,12 @@
   class="relative w-full aspect-[9/16] max-h-[70vh] sm:max-h-full sm:aspect-video"
   standardControls
 >
-  {#each layers as { data, color }, i}
+  {#each layers as { data, color, hoverCursor }, i}
     <GeoJson id="layer{i + 1}" data={{ type: 'FeatureCollection', features: data }} generateId>
       <CircleLayer
         {eventsIfTopMost}
         manageHoverState
+        {hoverCursor}
         paint={{
           'circle-color': color,
           'circle-radius': ['get', 'radius'],


### PR DESCRIPTION
openIfTopMost for Popups.

This PR does two separate things:
1) Make the existing `eventsIfTopMost` option also apply to setting hover state
2) Introduce a new `openIfTopMost` for Popups that works the same way

The existing demo page is extended to show all of this:

https://github.com/dimfeld/svelte-maplibre/assets/1664407/2c2046cc-1034-45eb-bde9-42fedab0a67e

