### PR TITLE
Plumb sourceLayer through setFeatureState, so hovering on vector tile

### DIFF
--- a/.changeset/eighty-bags-smash.md
+++ b/.changeset/eighty-bags-smash.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Fix hover state for vector tiles sources

--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -171,10 +171,16 @@
       if (featureId !== hoverFeatureId) {
         if (manageHoverState) {
           if (hoverFeatureId !== undefined) {
-            $map?.setFeatureState({ source: actualSource!, id: hoverFeatureId }, { hover: false });
+            $map?.setFeatureState(
+              { source: actualSource!, sourceLayer, id: hoverFeatureId },
+              { hover: false }
+            );
           }
 
-          $map?.setFeatureState({ source: actualSource!, id: featureId }, { hover: true });
+          $map?.setFeatureState(
+            { source: actualSource!, sourceLayer, id: featureId },
+            { hover: true }
+          );
         }
 
         hoverFeatureId = featureId;
@@ -202,7 +208,10 @@
 
       hovered = null;
       if (manageHoverState && hoverFeatureId !== undefined) {
-        $map?.setFeatureState({ source: actualSource!, id: hoverFeatureId }, { hover: false });
+        $map?.setFeatureState(
+          { source: actualSource!, sourceLayer, id: hoverFeatureId },
+          { hover: false }
+        );
         hoverFeatureId = undefined;
       }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -16,7 +16,7 @@ export { default as MapLibre } from './MapLibre.svelte';
 export { default as Marker } from './Marker.svelte';
 export { default as MarkerLayer } from './MarkerLayer.svelte';
 export { default as NavigationControl } from './NavigationControl.svelte';
-export { default as VectorTileSource } from "./VectorTileSource.svelte"
+export { default as VectorTileSource } from './VectorTileSource.svelte';
 export { default as Popup } from './Popup.svelte';
 export { default as ScaleControl } from './ScaleControl.svelte';
 export { default as SymbolLayer } from './SymbolLayer.svelte';


### PR DESCRIPTION
sources works.

I didn't change any example in this repo to demonstrate the problem or fix, because I don't have a pmtiles file in a stable place with feature IDs defined. My temporary diff for the `pmtiles_source` example used this:

```
+  import { hoverStateFilter } from '$lib/filters.ts';


   <VectorTileSource
-    url={'pmtiles://https://r2-public.protomaps.com/protomaps-sample-datasets/cb_2018_us_zcta510_500k.pmtiles'}
+    url={'pmtiles://https://atip.uk/layers/v1/wards.pmtiles'}
   > 
     <LineLayer
+      manageHoverState
       paint={{
         'line-opacity': 0.6,
         'line-color': 'rgb(53, 175, 109)',
-        'line-width': 2,
+        'line-width': hoverStateFilter(5, 10),
       }}
-      sourceLayer={'zcta'}
+      sourceLayer={'wards'}
     />
   </VectorTileSource>

```