### PR TITLE
feat: Re-export types from `maplibre-gl`

### DIFF
--- a/.changeset/tall-trainers-smash.md
+++ b/.changeset/tall-trainers-smash.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Re-export common types from `maplibre-gl`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,20 @@
 import type { Feature, Point } from 'geojson';
 import type { MapMouseEvent, Marker } from 'maplibre-gl';
 
+export type {
+  ControlPosition,
+  ExpressionSpecification,
+  Feature,
+  LayerSpecification,
+  LngLatBoundsLike,
+  LngLatLike,
+  Map,
+  Offset,
+  PointLike,
+  PositionAnchor,
+  StyleSpecification,
+} from 'maplibre-gl';
+
 export interface ClusterOptions {
   /** The minimum number of points required to form a cluster.
    * This can not be changed after the source is created.


### PR DESCRIPTION
This exports the most useful types so that installing the `maplibre-gl` package isn't required just to use things like the `Map` type