### PR TITLE
Fix GeoJSON so it reactively updates on style.load

### DIFF
--- a/.changeset/funny-pigs-drop.md
+++ b/.changeset/funny-pigs-drop.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Fix GeoJSON component reactivity to data changes after map styles are updated.

--- a/src/routes/examples/changing_basemap_style/+page.svelte
+++ b/src/routes/examples/changing_basemap_style/+page.svelte
@@ -7,7 +7,7 @@
   import code from './+page.svelte?raw';
   import CodeSample from '$site/CodeSample.svelte';
   import states from '$site/states.json?url';
-  import { hoverStateFilter } from '$lib/filters.js';
+  import type { FeatureCollection } from 'geojson';
 
   let showBorder = true;
   let showFill = true;
@@ -19,16 +19,46 @@
       ? 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'
       : 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 
-  console.log('selected ', selected, ' style ', style);
+  const coloradoPolygon = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-109, 37],
+              [-102, 37],
+              [-102, 41],
+              [-109, 41],
+              [-109, 37],
+            ],
+          ],
+        },
+      },
+    ],
+  } as FeatureCollection;
+
+  let dataOption: 'states' | 'colorado' = 'states';
+  $: dataset = dataOption === 'states' ? states : coloradoPolygon;
 </script>
 
-<select class="basemap-select" bind:value={selected}>
-  <option value="light">Light</option>
-  <option value="dark">dark</option>
-</select>
+<div class="controls">
+  <select class="controls-select" bind:value={selected}>
+    <option value="light">Light</option>
+    <option value="dark">dark</option>
+  </select>
+
+  <select class="controls-select" bind:value={dataOption}>
+    <option value="states">States Dataset</option>
+    <option value="colorado">Colorado Dataset</option>
+  </select>
+</div>
 
 <MapLibre {style} class={mapClasses} standardControls center={[-98.137, 40.137]} zoom={4}>
-  <GeoJSON id="states" data={states} promoteId="STATEFP">
+  <GeoJSON id="states" data={dataset} promoteId="STATEFP">
     {#if showFill}
       <FillLayer
         paint={{
@@ -51,10 +81,14 @@
 <CodeSample {code} />
 
 <style>
-  .grid {
-    grid-template-columns: repeat(auto-fill, 150px);
+  .controls {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    padding: 0.5rem;
   }
-  .basemap-select {
+
+  .controls-select {
     box-sizing: border-box;
     padding: 10px 20px;
   }


### PR DESCRIPTION
<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->

Fix GeoJSON component to update reference of `sourceObj` on the `style.load` event. Update the example to show this functionality.

https://github.com/dimfeld/svelte-maplibre/assets/34895686/e099aa5a-c06a-4220-8c67-61a8623418f4

closes #74