### PR TITLE
Add components to export map

### DIFF
--- a/.changeset/yellow-jeans-love.md
+++ b/.changeset/yellow-jeans-love.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': minor
+---
+
+Add all components to the export map. This allows importing like "svelte-maplibre/Maplibre.svelte" in addition to importing everything from the package root.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,26 @@
     ".": {
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js"
+    },
+    "./*.svelte": {
+      "types": "./dist/*.d.ts",
+      "svelte": "./dist/*.svelte"
+    },
+    "./context.js": {
+      "types": "./dist/context.d.ts",
+      "default": "./dist/context.js"
+    },
+    "./expressions.js": {
+      "types": "./dist/expressions.d.ts",
+      "default": "./dist/expressions.js"
+    },
+    "./filters.js": {
+      "types": "./dist/filters.d.ts",
+      "default": "./dist/filters.js"
+    },
+    "./types.js": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
     }
   },
   "svelte": "./dist/index.js",


### PR DESCRIPTION
<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->

This allows code such as `import GeoJSON from 'svelte-maplibre/GeoJSON.svelte'` if you don't want to use the barrel file.