### PR TITLE
Allow setting layers non-interactive

### DIFF
--- a/.changeset/short-balloons-pump.md
+++ b/.changeset/short-balloons-pump.md
@@ -1,0 +1,17 @@
+---
+'svelte-maplibre': major
+---
+
+Allow setting layers to be non-interactive. Layers with `interactive={false}` will not emit mouse events, and will not
+participate in hit testing when comparing to other layers with `eventsIfTopMost`.
+
+This is useful, for example, when placing a SymbolLayer on top of a
+CircleLayer. See the updated "Clusters and Popups" example; previous the popup would disappear when the mouse was over
+the labels, but not it does not.
+
+This is a breaking change:
+
+- The `interactive` prop for `Marker` and `MarkerLayer` has been renamed to `asButton`, to make room for the new
+    `interactive` prop.
+- DeckGlLayer still continues to allow the `pickable` prop, but `interactive` should be used instead for consistency.
+    The behavior here is unchanged though.

--- a/src/lib/CircleLayer.svelte
+++ b/src/lib/CircleLayer.svelte
@@ -27,6 +27,8 @@
   export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
+  /** Handle mouse events on this layer. */
+  export let interactive = true;
 </script>
 
 <Layer
@@ -45,6 +47,7 @@
   {hoverCursor}
   {manageHoverState}
   {eventsIfTopMost}
+  {interactive}
   bind:hovered
   on:click
   on:dblclick

--- a/src/lib/DeckGlLayer.svelte
+++ b/src/lib/DeckGlLayer.svelte
@@ -13,7 +13,11 @@
   export let minzoom: number | undefined = undefined;
   export let maxzoom: number | undefined = undefined;
   export let visible = true;
-  export let pickable = true;
+  /** Whether to handle mouse events on this layer.
+   * @deprecated Use `interactive` instead. */
+  export let pickable: boolean | undefined = undefined;
+  /** Handle mouse events on this layer. */
+  export let interactive = true;
 
   /** This indicates the currently hovered feature. Setting this attribute has no effect. */
   export let hovered: DATA | null = null;
@@ -55,7 +59,7 @@
     ...$$restProps,
     visible: visibility,
     data,
-    pickable,
+    pickable: pickable ?? interactive,
     onClick: handleClick,
     onHover: handleHover,
   };
@@ -66,12 +70,11 @@
     }
   }
 
-  // Need a way to pass events down to the popup.
-  // Don't set popupTarget and instead set some kind of event store
-  // that will set the event the popup is handling. Consider moving
-  // all popup event handling to this model.
-  // Convert marker to use layer event instead of special hover store
   function handleClick(e: DeckGlMouseEvent<DATA>) {
+    if (!interactive) {
+      return;
+    }
+
     dispatch('click', e);
     $layerEvent = {
       ...e,
@@ -81,6 +84,10 @@
   }
 
   function handleHover(e: DeckGlMouseEvent<DATA>) {
+    if (!interactive) {
+      return;
+    }
+
     const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
     hovered = e.object ?? null;
     dispatch(type, e);

--- a/src/lib/FillExtrusionLayer.svelte
+++ b/src/lib/FillExtrusionLayer.svelte
@@ -26,6 +26,8 @@
   export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
+  /** Handle mouse events on this layer. */
+  export let interactive = true;
 </script>
 
 <Layer
@@ -43,6 +45,7 @@
   {hoverCursor}
   {manageHoverState}
   {eventsIfTopMost}
+  {interactive}
   bind:hovered
   on:click
   on:dblclick

--- a/src/lib/FillLayer.svelte
+++ b/src/lib/FillLayer.svelte
@@ -26,6 +26,8 @@
   export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
+  /** Handle mouse events on this layer. */
+  export let interactive = true;
 </script>
 
 <Layer
@@ -43,6 +45,7 @@
   {hoverCursor}
   {manageHoverState}
   {eventsIfTopMost}
+  {interactive}
   bind:hovered
   on:click
   on:dblclick

--- a/src/lib/HeatmapLayer.svelte
+++ b/src/lib/HeatmapLayer.svelte
@@ -26,6 +26,8 @@
   export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
+  /** Handle mouse events on this layer. */
+  export let interactive = true;
 </script>
 
 <Layer
@@ -43,6 +45,7 @@
   {hoverCursor}
   {manageHoverState}
   {eventsIfTopMost}
+  {interactive}
   bind:hovered
   on:click
   on:dblclick

--- a/src/lib/LineLayer.svelte
+++ b/src/lib/LineLayer.svelte
@@ -26,6 +26,8 @@
   export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
+  /** Handle mouse events on this layer. */
+  export let interactive = true;
 </script>
 
 <Layer
@@ -43,6 +45,7 @@
   {hoverCursor}
   {manageHoverState}
   {eventsIfTopMost}
+  {interactive}
   bind:hovered
   on:click
   on:dblclick

--- a/src/lib/Marker.svelte
+++ b/src/lib/Marker.svelte
@@ -7,9 +7,10 @@
   export let lngLat: LngLatLike;
   let classNames: string | undefined = undefined;
   export { classNames as class };
-  /** If interactive is true (default), it will render as a `button`. If not,
-   * it will render as a `div` element. */
+  /** Handle mouse events */
   export let interactive = true;
+  /** Make markers tabbable and add the button role. */
+  export let asButton = false;
   export let draggable = false;
   /** A GeoJSON Feature related to the point. This is only actually used to send an ID and set of properties along with
    * the event, and can be safely omitted. The `lngLat` prop controls the marker's location even if this is provided. */
@@ -106,6 +107,10 @@
   }
 
   function sendEvent(eventName: string) {
+    if (!interactive) {
+      return;
+    }
+
     let loc = $marker?.getLngLat();
     if (!loc) {
       return;
@@ -144,8 +149,8 @@
   use:addMarker
   use:manageClasses={classNames}
   style:z-index={zIndex}
-  tabindex={interactive ? 0 : undefined}
-  role={interactive ? 'button' : undefined}
+  tabindex={asButton ? 0 : undefined}
+  role={asButton ? 'button' : undefined}
   on:click={() => sendEvent('click')}
   on:dblclick={() => sendEvent('dblclick')}
   on:contextmenu={() => sendEvent('contextmenu')}

--- a/src/lib/MarkerLayer.svelte
+++ b/src/lib/MarkerLayer.svelte
@@ -16,9 +16,10 @@
   /** How to calculate the coordinates of the marker.
    * @default Calls d3.geoCentroid` on the feature. */
   export let markerLngLat: (feature: Feature) => [number, number] = geoCentroid;
-  /** If interactive is true (default), the markers will render as `button`. If not,
-   * they will render as `div` elements. */
-  export let interactive = false;
+  /** Handle mouse events */
+  export let interactive = true;
+  /** Make markers tabbable and add the button role. */
+  export let asButton = false;
   export let draggable = false;
   export let minzoom: number | undefined = undefined;
   export let maxzoom: number | undefined = undefined;
@@ -135,6 +136,7 @@ the map as a layer. Markers for non-point features are placed at the geometry's 
     {@const c = markerLngLat(feature)}
     {@const z = typeof zIndex === 'function' ? zIndex(feature) : zIndex}
     <Marker
+      {asButton}
       {interactive}
       {draggable}
       class={className}

--- a/src/lib/SymbolLayer.svelte
+++ b/src/lib/SymbolLayer.svelte
@@ -27,6 +27,8 @@
   export let manageHoverState = false;
   export let hovered: Feature | null = null;
   export let eventsIfTopMost = false;
+  /** Handle mouse events on this layer. */
+  export let interactive = true;
 </script>
 
 <Layer
@@ -45,6 +47,7 @@
   {hoverCursor}
   {manageHoverState}
   {eventsIfTopMost}
+  {interactive}
   bind:hovered
   on:click
   on:dblclick

--- a/src/routes/examples/clusters/+page.svelte
+++ b/src/routes/examples/clusters/+page.svelte
@@ -24,7 +24,7 @@
   >
 </p>
 
-<fieldset class="border border-gray-300 self-start px-2 flex gap-x-4 mb-2">
+<fieldset class="mb-2 flex gap-x-4 self-start border border-gray-300 px-2">
   <legend>Show popup on</legend>
   <label><input type="radio" bind:group={openOn} value="hover" /> Hover</label>
   <label><input type="radio" bind:group={openOn} value="click" /> Click</label>
@@ -53,6 +53,7 @@
     }}
   >
     <CircleLayer
+      id="cluster_circles"
       applyToClusters
       hoverCursor="pointer"
       paint={{
@@ -76,6 +77,8 @@
     </CircleLayer>
 
     <SymbolLayer
+      id="cluster_labels"
+      interactive={false}
       applyToClusters
       layout={{
         'text-field': [
@@ -99,6 +102,7 @@
     />
 
     <CircleLayer
+      id="earthquakes_circle"
       applyToClusters={false}
       hoverCursor="pointer"
       paint={{

--- a/src/routes/examples/custom_marker_clusters/+page.svelte
+++ b/src/routes/examples/custom_marker_clusters/+page.svelte
@@ -25,7 +25,7 @@
   >
 </p>
 
-<fieldset class="border border-gray-300 self-start px-2 flex gap-x-4 mb-2">
+<fieldset class="mb-2 flex gap-x-4 self-start border border-gray-300 px-2">
   <legend>Show popup on</legend>
   <label><input type="radio" bind:group={openOn} value="hover" /> Hover</label>
   <label><input type="radio" bind:group={openOn} value="click" /> Click</label>
@@ -55,7 +55,7 @@
   >
     <MarkerLayer
       applyToClusters
-      interactive
+      asButton
       on:click={(e) => (clickedFeature = e.detail.feature?.properties)}
       let:feature
     >
@@ -74,6 +74,7 @@
 
     <MarkerLayer
       applyToClusters={false}
+      asButton
       on:click={(e) => (clickedFeature = e.detail.feature?.properties)}
       let:feature
     >


### PR DESCRIPTION
Allow setting layers to be non-interactive. Layers with `interactive={false}` will not emit mouse events, and will not
participate in hit testing when comparing to other layers with `eventsIfTopMost`.

This is useful, for example, when placing a SymbolLayer on top of a CircleLayer. See the updated "Clusters and Popups" example; previous the popup would disappear when the mouse was over the labels, but not it does not.

This is a breaking change:

- The `interactive` prop for `Marker` and `MarkerLayer` has been renamed to `asButton`, to make room for the new
    `interactive` prop.
- DeckGlLayer still continues to allow the `pickable` prop, but `interactive` should be used instead for consistency.
    The behavior here is unchanged though.
