### PR TITLE
Add "default" export condition

### DIFF
--- a/.changeset/nervous-coins-promise.md
+++ b/.changeset/nervous-coins-promise.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Add "default" export condition to help frameworks that don't add "svelte" to their list

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
+      "svelte": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./*.svelte": {
       "types": "./dist/*.d.ts",
-      "svelte": "./dist/*.svelte"
+      "svelte": "./dist/*.svelte",
+      "default": "./dist/*.svelte"
     },
     "./context.js": {
       "types": "./dist/context.d.ts",


### PR DESCRIPTION
Hopefully this should help with some frameworks that don't set their list of export conditions for Svelte

<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->
Fixes #107 i hope