### PR TITLE
Added Rotation to Marker

### DIFF
--- a/.changeset/chatty-chicken-fly.md
+++ b/.changeset/chatty-chicken-fly.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Added Rotation property to marker

--- a/src/lib/DefaultMarker.svelte
+++ b/src/lib/DefaultMarker.svelte
@@ -16,6 +16,8 @@
   export let feature: GeoJSON.Feature | null = null;
   /** An offset in pixels to apply to the marker. */
   export let offset: PointLike | undefined = undefined;
+  /** The rotation angle of the marker (clockwise, in degrees) */
+  export let rotation: number = 0;
 
   const dispatch = createEventDispatcher();
   const { map, layerEvent, self: marker } = updatedMarkerContext();
@@ -33,6 +35,7 @@
   $marker = new maplibre.Marker(
     flush({
       draggable,
+      rotation,
       className: classNames,
       offset,
     })
@@ -49,6 +52,7 @@
 
   $: $marker?.setLngLat(lngLat);
   $: $marker?.setOffset(offset ?? [0, 0]);
+  $: $marker?.setRotation(rotation);
 
   function propagateLngLatChange() {
     let newPos = $marker?.getLngLat();

--- a/src/lib/Marker.svelte
+++ b/src/lib/Marker.svelte
@@ -20,6 +20,8 @@
   export let offset: PointLike | undefined = undefined;
   /** The z-index of the marker. This can also be set via CSS classes using the `class` prop */
   export let zIndex: number | undefined = undefined;
+  /** The rotation angle of the marker (clockwise, in degrees) */
+  export let rotation: number = 0;
 
   const dispatch = createEventDispatcher();
   const { map, layerEvent, self: marker } = updatedMarkerContext();
@@ -27,6 +29,7 @@
   function addMarker(node: HTMLDivElement) {
     $marker = new maplibre.Marker({
       element: node,
+      rotation,
       draggable,
       offset,
     })
@@ -82,6 +85,7 @@
 
   $: $marker?.setLngLat(lngLat);
   $: $marker?.setOffset(offset ?? [0, 0]);
+  $: $marker?.setRotation(rotation);
 
   function propagateLngLatChange() {
     let newPos = $marker?.getLngLat();


### PR DESCRIPTION
Now marker have support of rotation
Equivalent to maplibre [rotation](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Marker/#setrotation) 

This closes [#116](https://github.com/dimfeld/svelte-maplibre/issues/116)