### PR TITLE
 Origin/cooperative gestures

### DIFF
--- a/.changeset/long-poets-obey.md
+++ b/.changeset/long-poets-obey.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre": minor
+---
+
+Add cooperativeGestures as svelte prop

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -40,6 +40,8 @@
   export let interactive = true;
   /** Set false to hide the default attribution control, so you can add your own. */
   export let attributionControl = true;
+  /**Set true to require hitting ⌘/Ctrl while scrolling to zoom. Or use two fingers on phones. Set custom help-texts with {windowHelpText, macHelpText, mobileHelpText} */
+  export let cooperativeGestures = false;
   /** Set to true if you want to export the map as an image */
   export let preserveDrawingBuffer = false;
   export let maxBounds: LngLatBoundsLike | undefined = undefined;
@@ -146,6 +148,7 @@
         bounds,
         attributionControl,
         transformRequest,
+        cooperativeGestures,
       })
     );
 

--- a/src/routes/NavBar.svelte
+++ b/src/routes/NavBar.svelte
@@ -34,6 +34,7 @@
     { href: '/examples/data_join', title: `Client Side Data Join` },
     { href: '/examples/raster_source', title: `Raster Source` },
     { href: '/examples/image_source', title: `Image Source` },
+    { href: '/examples/cooperative_gestures', title: `Cooperative Gestures` },
   ];
 
   // Examples which don't really warrant showing on the docs site, but ensure that

--- a/src/routes/examples/cooperative_gestures/+page.svelte
+++ b/src/routes/examples/cooperative_gestures/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import MapLibre from '$lib/MapLibre.svelte';
+  import CodeSample from '$site/CodeSample.svelte';
+  import code from './+page.svelte?raw';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
+</script>
+
+<p>
+  Enable cooperative gestures with a specific language. Set to <code>true</code> or use custom help-text
+  like below.
+</p>
+<p>
+  Scroll the map to see it in action. <a
+    href="https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/">MapLibre docs.</a
+  >
+</p>
+<br />
+
+<MapLibre
+  style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+  class="relative aspect-[9/16] max-h-[70vh] w-full sm:aspect-video sm:max-h-full"
+  cooperativeGestures={{
+    windowsHelpText: 'Utilice Ctrl + desplazamiento para hacer zoom en el mapa.',
+    macHelpText: 'Use ⌘ + desplazamiento para hacer zoom en el mapa.',
+    mobileHelpText: 'Usa dos dedos para mover el mapa.',
+  }}
+/>
+
+<CodeSample {code} startBoundary="<MapLibre" endBoundary="/>" />

--- a/src/routes/examples/cooperative_gestures/+page.ts
+++ b/src/routes/examples/cooperative_gestures/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = () => {
+  return {
+    title: 'Cooperative Gestures',
+  };
+};


### PR DESCRIPTION
Add cooperativeGestures as [documented on maplibre-gl ](https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/)

Set `cooperativeGestures=true` to prevent user not being able to scroll past the map.

As discussed on #120 