### PR TITLE
Support maplibre v4

### DIFF
--- a/.changeset/hungry-pumas-tan.md
+++ b/.changeset/hungry-pumas-tan.md
@@ -1,0 +1,13 @@
+---
+"svelte-maplibre": minor
+---
+
+Support maplibre v4
+
+All the breaking changes in the MaplibreGL JS v4 release apply here. Some specific API changes to this package:
+
+- Upgrade maplibregl-js to ^4.0.0
+- Upgrade pmtiles to ^3.0.3
+- `cooperativeGestures` prop is now just a boolean to match maplibre v4. 
+- Add `locale` property to MapLibre component.
+- Add `opacity` property for Markers

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "d3-geo": "^3.1.0",
     "just-compare": "^2.3.0",
     "just-flush": "^2.3.0",
-    "maplibre-gl": "^3.5.0",
-    "pmtiles": "^2.10.0"
+    "maplibre-gl": "^4.0.0",
+    "pmtiles": "^3.0.3"
   },
   "peerDependencies": {
     "@deck.gl/core": "^8.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ dependencies:
     specifier: ^2.3.0
     version: 2.3.0
   maplibre-gl:
-    specifier: ^3.5.0
-    version: 3.5.0
+    specifier: ^4.0.0
+    version: 4.0.0
   pmtiles:
-    specifier: ^2.10.0
-    version: 2.10.0
+    specifier: ^3.0.3
+    version: 3.0.3
 
 devDependencies:
   '@changesets/changelog-github':
@@ -936,13 +936,13 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
-  /@maplibre/maplibre-gl-style-spec@19.3.3:
-    resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
+  /@maplibre/maplibre-gl-style-spec@20.1.1:
+    resolution: {integrity: sha512-z85ARNPCBI2Cs5cPOS3DSbraTN+ue8zrcYVoSWBuNrD/mA+2SKAJ+hIzI22uN7gac6jBMnCdpPKRxS/V0KSZVQ==}
     hasBin: true
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/unitbezier': 0.0.1
-      json-stringify-pretty-compact: 3.0.0
+      json-stringify-pretty-compact: 4.0.0
       minimist: 1.2.8
       rw: 1.3.3
       sort-object: 3.0.3
@@ -1283,12 +1283,18 @@ packages:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
 
+  /@types/geojson-vt@3.2.5:
+    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
+    dependencies:
+      '@types/geojson': 7946.0.14
+    dev: false
+
   /@types/geojson@7946.0.10:
     resolution: {integrity: sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==}
     dev: true
 
-  /@types/geojson@7946.0.12:
-    resolution: {integrity: sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA==}
+  /@types/geojson@7946.0.14:
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
     dev: false
 
   /@types/hammerjs@2.0.41:
@@ -1305,22 +1311,28 @@ packages:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
+  /@types/leaflet@1.9.8:
+    resolution: {integrity: sha512-EXdsL4EhoUtGm2GC2ZYtXn+Fzc6pluVgagvo2VC1RHWToLGlTRwVYoDpqS/7QXa01rmDyBjJk3Catpf60VMkwg==}
+    dependencies:
+      '@types/geojson': 7946.0.14
+    dev: false
+
   /@types/mapbox-gl@2.7.10:
     resolution: {integrity: sha512-nMVEcu9bAcenvx6oPWubQSPevsekByjOfKjlkr+8P91vawtkxTnopDoXXq1Qn/f4cg3zt0Z2W9DVsVsKRNXJTw==}
     dependencies:
       '@types/geojson': 7946.0.10
     dev: true
 
-  /@types/mapbox__point-geometry@0.1.2:
-    resolution: {integrity: sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==}
+  /@types/mapbox__point-geometry@0.1.4:
+    resolution: {integrity: sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==}
     dev: false
 
-  /@types/mapbox__vector-tile@1.3.3:
-    resolution: {integrity: sha512-d263B3KCQtXKVZMHpMJrEW5EeLBsQ8jvAS9nhpUKC5hHIlQaACG9PWkW8qxEeNuceo9120AwPjeS91uNa4ltqA==}
+  /@types/mapbox__vector-tile@1.3.4:
+    resolution: {integrity: sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==}
     dependencies:
-      '@types/geojson': 7946.0.12
-      '@types/mapbox__point-geometry': 0.1.2
-      '@types/pbf': 3.0.4
+      '@types/geojson': 7946.0.14
+      '@types/mapbox__point-geometry': 0.1.4
+      '@types/pbf': 3.0.5
     dev: false
 
   /@types/minimist@1.2.2:
@@ -1343,8 +1355,8 @@ packages:
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
     dev: true
 
-  /@types/pbf@3.0.4:
-    resolution: {integrity: sha512-SOFlLGZkLbEXJRwcWCqeP/Koyaf/uAqLXHUsdo/nMfjLsNd8kqauwHe9GBOljSmpcHp/LC6kOjo3SidGjNirVA==}
+  /@types/pbf@3.0.5:
+    resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
     dev: false
 
   /@types/pug@2.0.9:
@@ -1355,10 +1367,10 @@ packages:
     resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
     dev: true
 
-  /@types/supercluster@7.1.2:
-    resolution: {integrity: sha512-qMhofL945Z4njQUuntadexAgPtpiBC014WvVqU70Prj42LC77Xgmz04us7hSMmwjs7KbgAwGBmje+FSOvDbP0Q==}
+  /@types/supercluster@7.1.3:
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
     dependencies:
-      '@types/geojson': 7946.0.12
+      '@types/geojson': 7946.0.14
     dev: false
 
   /@typescript-eslint/eslint-plugin@7.0.1(@typescript-eslint/parser@7.0.1)(eslint@8.56.0)(typescript@5.3.3):
@@ -3418,8 +3430,8 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json-stringify-pretty-compact@3.0.0:
-    resolution: {integrity: sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==}
+  /json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
     dev: false
 
   /jsonc-parser@3.2.0:
@@ -3639,8 +3651,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /maplibre-gl@3.5.0:
-    resolution: {integrity: sha512-kPEBz6r1LBOZjUpFy+4wZU5Nvnkr60wBtYN/JD6N7oaA4Prpe21afYKxi1oWzSPSfspS1tWNF18GlpF2XcmNSA==}
+  /maplibre-gl@4.0.0:
+    resolution: {integrity: sha512-bzVQ2pdOWITwbE+JHKSiAB/viVBBx4Aa1puydc1xizOWGbvRHD9pXpy3dsaW2ZlbmZKbv9r9sHpcvM9fTLGsKA==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
@@ -3650,12 +3662,13 @@ packages:
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 1.3.1
       '@mapbox/whoots-js': 3.1.0
-      '@maplibre/maplibre-gl-style-spec': 19.3.3
-      '@types/geojson': 7946.0.12
-      '@types/mapbox__point-geometry': 0.1.2
-      '@types/mapbox__vector-tile': 1.3.3
-      '@types/pbf': 3.0.4
-      '@types/supercluster': 7.1.2
+      '@maplibre/maplibre-gl-style-spec': 20.1.1
+      '@types/geojson': 7946.0.14
+      '@types/geojson-vt': 3.2.5
+      '@types/mapbox__point-geometry': 0.1.4
+      '@types/mapbox__vector-tile': 1.3.4
+      '@types/pbf': 3.0.5
+      '@types/supercluster': 7.1.3
       earcut: 2.2.4
       geojson-vt: 3.2.1
       gl-matrix: 3.4.3
@@ -4189,9 +4202,10 @@ packages:
     hasBin: true
     dev: true
 
-  /pmtiles@2.10.0:
-    resolution: {integrity: sha512-X+s6JyperpcAkKwv55MKx72ckOUB0ZjcfK4929iM0SS0MkLydEi2FSW1E8YTE1E2XaZ2TVk/MIUrbsZuXV7K2g==}
+  /pmtiles@3.0.3:
+    resolution: {integrity: sha512-tj4l3HHJd6/qf9VefzlPK2eYEQgbf+4uXPzNlrj3k7hHvLtibYSxfp51TF6ALt4YezM8MCdiOminnHvdAyqyGg==}
     dependencies:
+      '@types/leaflet': 1.9.8
       fflate: 0.8.1
     dev: false
 

--- a/src/lib/DefaultMarker.svelte
+++ b/src/lib/DefaultMarker.svelte
@@ -18,6 +18,8 @@
   export let offset: PointLike | undefined = undefined;
   /** The rotation angle of the marker (clockwise, in degrees) */
   export let rotation: number = 0;
+  /** The opacity of the marker */
+  export let opacity: number = 1;
 
   const dispatch = createEventDispatcher();
   const { map, layerEvent, self: marker } = updatedMarkerContext();
@@ -38,6 +40,7 @@
       rotation,
       className: classNames,
       offset,
+      opacity: opacity.toString(),
     })
   )
     .setLngLat(lngLat)
@@ -53,6 +56,7 @@
   $: $marker?.setLngLat(lngLat);
   $: $marker?.setOffset(offset ?? [0, 0]);
   $: $marker?.setRotation(rotation);
+  $: $marker?.setOpacity(opacity.toString());
 
   function propagateLngLatChange() {
     let newPos = $marker?.getLngLat();

--- a/src/lib/Marker.svelte
+++ b/src/lib/Marker.svelte
@@ -22,6 +22,8 @@
   export let zIndex: number | undefined = undefined;
   /** The rotation angle of the marker (clockwise, in degrees) */
   export let rotation: number = 0;
+  /** The opacity of the marker */
+  export let opacity: number = 1;
 
   const dispatch = createEventDispatcher();
   const { map, layerEvent, self: marker } = updatedMarkerContext();
@@ -32,6 +34,7 @@
       rotation,
       draggable,
       offset,
+      opacity: opacity.toString(),
     })
       .setLngLat(lngLat)
       .addTo($map);
@@ -86,6 +89,7 @@
   $: $marker?.setLngLat(lngLat);
   $: $marker?.setOffset(offset ?? [0, 0]);
   $: $marker?.setRotation(rotation);
+  $: $marker?.setOpacity(opacity.toString());
 
   function propagateLngLatChange() {
     let newPos = $marker?.getLngLat();

--- a/src/routes/examples/ClusterPopup.svelte
+++ b/src/routes/examples/ClusterPopup.svelte
@@ -10,7 +10,8 @@
   $: if ($map && $source && feature) {
     $map
       ?.getSource($source)
-      ?.getClusterLeaves(feature.properties.cluster_id, 10000, 0, (err, features) => {
+      ?.getClusterLeaves(feature.properties.cluster_id, 10000, 0)
+      .then((features) => {
         innerFeatures = features;
       });
   }

--- a/src/routes/examples/cooperative_gestures/+page.svelte
+++ b/src/routes/examples/cooperative_gestures/+page.svelte
@@ -8,8 +8,9 @@
 </script>
 
 <p>
-  Enable cooperative gestures with a specific language. Set to <code>true</code> or use custom help-text
-  like below.
+  Enable cooperative gestures, which configures the map's zoom functionality to not override the
+  usual scroll methods. The strings displayed can be changed using the `locale` option, as shown
+  below.
 </p>
 <p>
   Scroll the map to see it in action. <a
@@ -21,10 +22,12 @@
 <MapLibre
   style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
   class="relative aspect-[9/16] max-h-[70vh] w-full sm:aspect-video sm:max-h-full"
-  cooperativeGestures={{
-    windowsHelpText: 'Utilice Ctrl + desplazamiento para hacer zoom en el mapa.',
-    macHelpText: 'Use ⌘ + desplazamiento para hacer zoom en el mapa.',
-    mobileHelpText: 'Usa dos dedos para mover el mapa.',
+  cooperativeGestures
+  locale={{
+    'CooperativeGesturesHandler.WindowsHelpText':
+      'Utilice Ctrl + desplazamiento para hacer zoom en el mapa.',
+    'CooperativeGesturesHandler.MacHelpText': 'Usa ⌘ + desplazamiento para hacer zoom en el mapa.',
+    'CooperativeGesturesHandler.MobileHelpText': 'Usa dos dedos para mover el mapa.',
   }}
 />
 


### PR DESCRIPTION
Resolves #125 

I'll probably let this sit here for a day or two in case anyone else wants to try it and potentially catch any problems before I merge.

- Upgrade maplibregl-js to ^4.0.0
- Upgrade pmtiles to ^3.0.3
- `cooperativeGestures` prop is now just a boolean to match maplibre v4. 
- Add `locale` property to MapLibre component.
- Add `opacity` property for Markers