### PR TITLE
Clarify Typescript types for MaplibreMap slot

### DIFF
--- a/.changeset/ten-crabs-draw.md
+++ b/.changeset/ten-crabs-draw.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre": minor
+---
+
+Fix typing for `map` prop in slot

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -270,6 +270,17 @@
   $: zoomOnDoubleClick
     ? $mapInstance?.doubleClickZoom.enable()
     : $mapInstance?.doubleClickZoom.disable();
+
+  // https://github.com/dummdidumm/rfcs/blob/ts-typedefs-within-svelte-components/text/ts-typing-props-slots-events.md#typing-slots
+  interface $$Slots {
+    default: {
+      // `map` is always a MaplibreMap, never `null`
+      map: maplibregl.Map;
+      // the other slot props are correctly autodetected
+      loadedImages: Set<string>;
+      allImagesLoaded: boolean;
+    };
+  }
 </script>
 
 <div class={classNames} class:expand-map={!classNames} use:createMap>


### PR DESCRIPTION
Typescript was incorrectly detecting the type of the `map` prop in the `<MaplibreMap>` slot to be type `maplibregl.Map | null`. This is understandable, since that is the type of the store in the `MapLibre.svelte` file, but in order for the child components to be rendered, the store cannot be `null`. As a result, the type was too wide.

The Svelte documentation states that [it's possible to override the detected types](https://svelte.dev/docs/typescript#experimental-advanced-typings) using some advanced typing systems. It notes that "The API is experimental and may change at any point," but for now, this seems to be the right way to accomplish this.

I don't know if this change should be considered "minor" or "patch" level; feel free to change the changeset, if you want!