### PR TITLE
WIP: e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 /dist
 ghtoken
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@deck.gl/core": "^8.8.0",
     "@deck.gl/layers": "^8.8.0",
     "@deck.gl/mapbox": "^8.8.0",
-    "@playwright/test": "^1.28.1",
+    "@playwright/test": "^1.42.0",
     "@skeletonlabs/skeleton": "^1.0.0",
     "@sveltejs/adapter-vercel": "^4.0.0",
     "@sveltejs/kit": "^2.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,12 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
-	webServer: {
-		command: 'npm run build && npm run preview',
-		port: 4173
-	},
-	testDir: 'tests'
+  webServer: {
+    command: 'npm run build && npm run preview',
+    port: 4173,
+  },
+  testDir: 'tests',
+  testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 };
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ devDependencies:
     specifier: ^8.8.0
     version: 8.8.26(@deck.gl/core@8.8.26)
   '@playwright/test':
-    specifier: ^1.28.1
-    version: 1.30.0
+    specifier: ^1.42.0
+    version: 1.42.1
   '@skeletonlabs/skeleton':
     specifier: ^1.0.0
     version: 1.0.0
@@ -1000,13 +1000,12 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@playwright/test@1.30.0:
-    resolution: {integrity: sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==}
-    engines: {node: '>=14'}
+  /@playwright/test@1.42.1:
+    resolution: {integrity: sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==}
+    engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      '@types/node': 18.14.0
-      playwright-core: 1.30.0
+      playwright: 1.42.1
     dev: true
 
   /@polka/url@1.0.0-next.21:
@@ -1341,10 +1340,6 @@ packages:
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-    dev: true
-
-  /@types/node@18.14.0:
-    resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -2841,6 +2836,14 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4196,10 +4199,20 @@ packages:
       pathe: 1.1.1
     dev: true
 
-  /playwright-core@1.30.0:
-    resolution: {integrity: sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==}
-    engines: {node: '>=14'}
+  /playwright-core@1.42.1:
+    resolution: {integrity: sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==}
+    engines: {node: '>=16'}
     hasBin: true
+    dev: true
+
+  /playwright@1.42.1:
+    resolution: {integrity: sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.42.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /pmtiles@3.0.3:

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -165,6 +165,8 @@
     );
 
     $mapInstance.on('load', (e) => {
+      e.target.getContainer().setAttribute('data-testid', 'map');
+      e.target.getCanvas().setAttribute('data-testid', 'map-canvas');
       loaded = true;
       dispatch('load', $mapInstance!);
     });
@@ -302,7 +304,7 @@
   }
 </script>
 
-<div class={classNames} class:expand-map={!classNames} use:createMap>
+<div class={classNames} class:expand-map={!classNames} use:createMap data-testid="map-container">
   {#if $mapInstance && loaded}
     {#if standardControls}
       <NavigationControl position={standardControlsPosition} />

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+import { getMapContainer, getMapCanvas } from './util';
+
+test.describe('Basic', async () => {
+  test('render basic map', async ({ page }) => {
+    await page.goto('/examples/basic');
+    const mapContainer = getMapContainer(page);
+    await expect(mapContainer).toBeVisible();
+    const mapCanvas = getMapCanvas(page);
+    await expect(mapCanvas).toBeVisible();
+  });
+});

--- a/tests/marker.spec.ts
+++ b/tests/marker.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+import { getMap } from './util';
+
+test.describe('Default Markers', async () => {
+  test('render 6 markers', async ({ page }) => {
+    await page.goto('/examples/marker');
+    const map = getMap(page);
+    const markers = await map.locator('div.maplibregl-marker');
+    await expect(markers).toHaveCount(6);
+  });
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('index page has expected h1', async ({ page }) => {
-	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
-});

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,13 @@
+import { type Page } from '@playwright/test';
+
+export function getMapContainer(page: Page) {
+  return page.getByTestId('map-container');
+}
+
+export function getMap(page: Page) {
+  return page.getByTestId('map');
+}
+
+export function getMapCanvas(page: Page) {
+  return page.getByTestId('map-canvas');
+}


### PR DESCRIPTION
<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->
I found this library incredibly helpful, if you find it useful I could help by adding e2e tests for the documentation pages or specific components.
This might come useful when updating to svelte 5 too.
I added a couple of easy check on dom elements, for more advanced cases I could use [playwring's visual testing](https://playwright.dev/docs/test-snapshots) to check the canvas view.