### PR TITLE
Update the viewport when the URL hash changes

### DIFF
--- a/.changeset/shaggy-cycles-arrive.md
+++ b/.changeset/shaggy-cycles-arrive.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre": patch
+---
+
+Update the viewport when the URL hash changes

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -131,17 +131,7 @@
   let sourcesToReAddAfterStyleChange: Record<string, SourceSpecification> | undefined = undefined;
 
   function createMap(element: HTMLDivElement) {
-    if (hash) {
-      let parts = parseViewportHash(window.location.hash);
-      if (parts.length >= 3) {
-        zoom = parts[0];
-        center = [parts[2], parts[1]];
-      }
-      if (parts.length == 5) {
-        bearing = parts[3];
-        pitch = parts[4];
-      }
-    }
+    onHashChange();
 
     $mapInstance = new maplibre.Map(
       flush({
@@ -302,7 +292,23 @@
       allImagesLoaded: boolean;
     };
   }
+
+  function onHashChange() {
+    if (hash) {
+      let parts = parseViewportHash(window.location.hash);
+      if (parts.length >= 3) {
+        zoom = parts[0];
+        center = [parts[2], parts[1]];
+      }
+      if (parts.length == 5) {
+        bearing = parts[3];
+        pitch = parts[4];
+      }
+    }
+  }
 </script>
+
+<svelte:window on:hashchange={onHashChange} />
 
 <div class={classNames} class:expand-map={!classNames} use:createMap data-testid="map-container">
   {#if $mapInstance && loaded}


### PR DESCRIPTION
I missed a piece in #69 -- when the URL changes, the viewport needs adjusting. It's quite handy to copy a map hash from another site. Tested manually with the `geojson_line_layer` example.