### PR TITLE
Stop propagation of clicks on Markers

### DIFF
--- a/.changeset/thirty-rivers-cover.md
+++ b/.changeset/thirty-rivers-cover.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre": minor
+---
+
+Stop propagation of clicks on Markers

--- a/src/lib/Marker.svelte
+++ b/src/lib/Marker.svelte
@@ -165,9 +165,9 @@
   style:z-index={zIndex}
   tabindex={asButton ? 0 : undefined}
   role={asButton ? 'button' : undefined}
-  on:click={() => sendEvent('click')}
-  on:dblclick={() => sendEvent('dblclick')}
-  on:contextmenu={() => sendEvent('contextmenu')}
+  on:click|stopPropagation={() => sendEvent('click')}
+  on:dblclick|stopPropagation={() => sendEvent('dblclick')}
+  on:contextmenu|stopPropagation={() => sendEvent('contextmenu')}
   on:mouseenter={(e) => {
     sendEvent('mouseenter');
   }}


### PR DESCRIPTION
Related to #155. If you want to be able to click an empty part of the map and distinguish that from clicking an existing Marker, then I think this is necessary. I don't know if this is reasonable default behavior, or if it should be configurable though.

Testing in an external project, https://acteng.github.io/inspectorate_tools/route_check/critical_issues_log (subject to change).
https://github.com/acteng/inspectorate_tools/blob/main/src/routes/route_check/critical_issues_log/%2Bpage.svelte
I can modify an example here to demonstrate the change, if it's helpful