### PR TITLE
Add MapEvents component

### DIFF
--- a/.changeset/weak-spoons-fetch.md
+++ b/.changeset/weak-spoons-fetch.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre": minor
+---
+
+Add MapEvents component that makes it easier to subscribe to map events from inside Map components

--- a/src/lib/MapEvents.svelte
+++ b/src/lib/MapEvents.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy } from 'svelte';
+  import { mapContext } from './context';
+  import maplibregl from 'maplibre-gl';
+  import type { MapEventType, MapLayerEventType } from 'maplibre-gl';
+
+  const dispatch = createEventDispatcher<{
+    click: maplibregl.MapMouseEvent & { map: maplibregl.Map };
+    dblclick: maplibregl.MapMouseEvent & { map: maplibregl.Map };
+    contextmenu: maplibregl.MapMouseEvent & { map: maplibregl.Map };
+    movestart: maplibregl.MapMouseEvent & { map: maplibregl.Map };
+    moveend: maplibregl.MapMouseEvent & { map: maplibregl.Map };
+    zoomstart: maplibregl.MapLibreZoomEvent & { map: maplibregl.Map };
+    zoom: maplibregl.MapLibreZoomEvent & { map: maplibregl.Map };
+    zoomend: maplibregl.MapLibreZoomEvent & { map: maplibregl.Map };
+  }>();
+
+  /** Limit the event handlers to a certain layer. */
+  export let layer: string | undefined = undefined;
+
+  const { map } = mapContext();
+
+  function sendEvent(e: maplibregl.MapLibreEvent<unknown>) {
+    dispatch(
+      // @ts-expect-error
+      e.type,
+      { ...e, map }
+    );
+  }
+
+  const layerEvents: Array<keyof MapLayerEventType> = [
+    'click',
+    'dblclick',
+    'mousedown',
+    'mouseup',
+    'mousemove',
+    'mouseenter',
+    'mouseleave',
+    'contextmenu',
+    'mouseover',
+    'mouseout',
+  ];
+
+  const mapEvents: Array<keyof MapEventType> = [
+    'click',
+    'dblclick',
+    'contextmenu',
+    'mousemove',
+    'movestart',
+    'moveend',
+    'zoomstart',
+    'zoom',
+    'zoomend',
+  ];
+
+  $: if ($map) {
+    if (layer) {
+      for (const eventName of layerEvents) {
+        $map.on(eventName, layer, sendEvent);
+      }
+    } else {
+      for (const eventName of mapEvents) {
+        $map.on(eventName, sendEvent);
+      }
+    }
+  }
+
+  onDestroy(() => {
+    if ($map) {
+      if (layer) {
+        for (const eventName of layerEvents) {
+          $map.off(eventName, layer, sendEvent);
+        }
+      } else {
+        for (const eventName of mapEvents) {
+          $map.off(eventName, sendEvent);
+        }
+      }
+    }
+  });
+</script>

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -69,6 +69,9 @@
   const dispatch = createEventDispatcher<{
     load: maplibregl.Map;
     error: Error;
+    click: maplibregl.MapMouseEvent & { map: maplibregl.Map };
+    dblclick: maplibregl.MapMouseEvent & { map: maplibregl.Map };
+    contextmenu: maplibregl.MapMouseEvent & { map: maplibregl.Map };
     movestart: maplibregl.MapMouseEvent & { map: maplibregl.Map };
     moveend: maplibregl.MapMouseEvent & { map: maplibregl.Map };
     zoomstart: maplibregl.MapLibreZoomEvent & { map: maplibregl.Map };
@@ -180,6 +183,9 @@
       }
     });
 
+    $mapInstance.on('click', (ev) => dispatch('click', { ...ev, map: $mapInstance }));
+    $mapInstance.on('dblclick', (ev) => dispatch('dblclick', { ...ev, map: $mapInstance }));
+    $mapInstance.on('contextmenu', (ev) => dispatch('contextmenu', { ...ev, map: $mapInstance }));
     $mapInstance.on('zoomstart', (ev) => dispatch('zoomstart', { ...ev, map: $mapInstance }));
     $mapInstance.on('zoom', (ev) => {
       zoom = ev.target.getZoom();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,6 +15,7 @@ export { default as ImageSource } from './ImageSource.svelte';
 export { default as JoinedData } from './JoinedData.svelte';
 export { default as Layer } from './Layer.svelte';
 export { default as LineLayer } from './LineLayer.svelte';
+export { default as MapEvents } from './MapEvents.svelte';
 export { default as MapLibre } from './MapLibre.svelte';
 export { default as Marker } from './Marker.svelte';
 export { default as MarkerLayer } from './MarkerLayer.svelte';

--- a/src/routes/NavBar.svelte
+++ b/src/routes/NavBar.svelte
@@ -14,6 +14,7 @@
     { href: '/examples/basic', title: `Plain Map` },
     { href: '/examples/marker', title: `Default Markers` },
     { href: '/examples/custom_marker', title: `Custom Markers` },
+    { href: '/examples/marker_on_click', title: `Add Marker On Click` },
     { href: '/examples/draggable_custom_marker', title: `Custom draggable Markers` },
     { href: '/examples/popup_remote', title: `Remote Popup Data` },
     { href: '/examples/geojson_polygon', title: `GeoJSON Filled Polygon` },

--- a/src/routes/examples/marker_on_click/+page.svelte
+++ b/src/routes/examples/marker_on_click/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import MapLibre from '$lib/MapLibre.svelte';
+  import CodeSample from '$site/CodeSample.svelte';
+  import MapEvents from '$lib/MapEvents.svelte';
+  import code from './+page.svelte?raw';
+  import DefaultMarker from '$lib/DefaultMarker.svelte';
+  import type { LngLat, MapMouseEvent } from 'maplibre-gl';
+
+  let markers: { lngLat: LngLat }[] = [];
+
+  // START SAMPLE 1
+  function addMarker(e: CustomEvent<MapMouseEvent>) {
+    markers = [...markers, { lngLat: e.detail.lngLat }];
+  }
+  // END SAMPLE 1
+</script>
+
+<MapLibre
+  style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+  class="relative aspect-[9/16] max-h-[70vh] w-full sm:aspect-video sm:max-h-full"
+  standardControls
+>
+  <!-- MapEvents gives you access to map events even from other components inside the map,
+  where you might not have access to the top-level `MapLibre` component. In this case
+  it would also work to just use on:click on the MapLibre component itself. -->
+  <MapEvents on:click={addMarker} />
+
+  {#each markers as marker}
+    <DefaultMarker lngLat={marker.lngLat} />
+  {/each}
+</MapLibre>
+
+<CodeSample
+  {code}
+  language="typescript"
+  startBoundary="// START SAMPLE 1"
+  endBoundary="// END SAMPLE 1"
+  omitStartBoundary
+  omitEndBoundary
+/>
+<CodeSample {code} />

--- a/src/routes/examples/marker_on_click/+page.ts
+++ b/src/routes/examples/marker_on_click/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = () => {
+  return {
+    title: 'Add Marker on Click',
+  };
+};


### PR DESCRIPTION
<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->
This makes it easier to subscribe to map events from a component that's nested somewhere inside the map.

Still need to test and add a demo before I can merge.

Resolves #57
Resolves #155
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
