### PR TITLE
use easeTo, handle bearing and pitch

### DIFF
--- a/.changeset/angry-dancers-run.md
+++ b/.changeset/angry-dancers-run.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre": patch
+---
+
+Use easeTo so that simultaneous changes to center and zoom work properly

--- a/.changeset/famous-ducks-rescue.md
+++ b/.changeset/famous-ducks-rescue.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre": patch
+---
+
+Handle changes in bearing and pitch

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -4,6 +4,7 @@
   import { createMapContext } from './context.js';
   import { getViewportHash, parseViewportHash } from './hash.js';
   import maplibre, {
+    type CenterZoomBearing,
     type GestureOptions,
     type LayerSpecification,
     type LngLatBoundsLike,
@@ -175,6 +176,8 @@
     $mapInstance.on('moveend', (ev) => {
       center = ev.target.getCenter();
       zoom = ev.target.getZoom();
+      pitch = ev.target.getPitch();
+      bearing = ev.target.getBearing();
       bounds = ev.target.getBounds();
       dispatch('moveend', { ...ev, map: $mapInstance });
       if (hash) {
@@ -188,11 +191,9 @@
     $mapInstance.on('contextmenu', (ev) => dispatch('contextmenu', { ...ev, map: $mapInstance }));
     $mapInstance.on('zoomstart', (ev) => dispatch('zoomstart', { ...ev, map: $mapInstance }));
     $mapInstance.on('zoom', (ev) => {
-      zoom = ev.target.getZoom();
       dispatch('zoom', { ...ev, map: $mapInstance });
     });
     $mapInstance.on('zoomend', (ev) => {
-      zoom = ev.target.getZoom();
       dispatch('zoomend', { ...ev, map: $mapInstance });
     });
 
@@ -286,8 +287,29 @@
     loadingImages = new Set();
   }
 
-  $: if (center && !compare(center, $mapInstance?.getCenter())) $mapInstance?.panTo(center);
-  $: if (zoom && !compare(zoom, $mapInstance?.getZoom())) $mapInstance?.zoomTo(zoom);
+  $: if ($mapInstance) {
+    let options: CenterZoomBearing & { pitch?: number } = {};
+    if (center != null && !compare(center, $mapInstance?.getCenter())) {
+      options.center = center;
+    }
+
+    if (zoom != null && !compare(zoom, $mapInstance?.getZoom())) {
+      options.zoom = zoom;
+    }
+
+    if (bearing != null && !compare(bearing, $mapInstance?.getBearing())) {
+      options.bearing = bearing;
+    }
+
+    if (pitch != null && !compare(pitch, $mapInstance?.getPitch())) {
+      options.pitch = pitch;
+    }
+
+    if (Object.keys(options).length) {
+      $mapInstance.easeTo(options);
+    }
+  }
+
   $: if (bounds && !compare(bounds, $mapInstance?.getBounds())) $mapInstance?.fitBounds(bounds);
   $: zoomOnDoubleClick
     ? $mapInstance?.doubleClickZoom.enable()

--- a/src/routes/NavBar.svelte
+++ b/src/routes/NavBar.svelte
@@ -47,6 +47,7 @@
     { href: '/tests/marker-class-update', title: `Marker Class Update` },
     { href: '/tests/marker-z-index', title: `Marker Z-Index` },
     { href: '/tests/replace_source', title: `Replace a Source` },
+    { href: '/tests/change_center_zoom', title: `Change Center and Zoom` },
   ];
 
   beforeNavigate(() => {

--- a/src/routes/tests/change_center_zoom/+page.svelte
+++ b/src/routes/tests/change_center_zoom/+page.svelte
@@ -1,45 +1,88 @@
 <script lang="ts">
-  import type { LngLatLike } from 'maplibre-gl';
+  import type { LngLatLike, MapMouseEvent } from 'maplibre-gl';
   import MapLibre from '$lib/MapLibre.svelte';
   import CodeSample from '$site/CodeSample.svelte';
   import code from './+page.svelte?raw';
 
-  let center: LngLatLike = [0, 0];
-  let zoom = 2;
+  let coords = [
+    {
+      center: [116, -34],
+      zoom: 8,
+      pitch: 30,
+      bearing: 30,
+    },
+    {
+      center: [-107, 40],
+      zoom: 3,
+      pitch: 0,
+      bearing: 210,
+    },
+  ] as { center: [number, number]; zoom: number; pitch: number; bearing: number }[];
 
-  let newZoom = zoom;
-  let newCenter = center;
+  let center: LngLatLike = coords[0].center;
+  let zoom = coords[0].zoom;
+  let bearing = coords[0].bearing;
+  let pitch = coords[0].pitch;
 
-  function apply() {
+  let currentIndex = 0;
+  function toggle() {
+    currentIndex = (currentIndex + 1) % coords.length;
+    const {
+      center: newCenter,
+      zoom: newZoom,
+      bearing: newBearing,
+      pitch: newPitch,
+    } = coords[currentIndex];
     center = newCenter;
     zoom = newZoom;
+    bearing = newBearing;
+    pitch = newPitch;
   }
+
+  function quickToggle() {
+    toggle();
+    setTimeout(() => toggle(), 200);
+  }
+
+  let currentCoords = center;
+  let currentZoom = zoom;
+  let currentBearing = bearing;
+  let currentPitch = pitch;
+
+  function handleMoveEnd(ev: CustomEvent<MapMouseEvent>) {
+    const map = ev.detail.target;
+    let center = map.getCenter();
+    currentCoords = [center.lng, center.lat];
+    currentZoom = map.getZoom();
+    currentBearing = map.getBearing();
+    currentPitch = map.getPitch();
+  }
+
+  // when working correctly, the Toggle button should successfully change all the values, and Quick Toggle should end up
+  // back at the current coordinates.
 </script>
 
 <div class="flex gap-4">
-  <label>
-    Longitude
-    <input type="number" class="input" bind:value={newCenter[0]} />
-  </label>
-  <label>
-    Latitude
-    <input type="number" class="input" bind:value={newCenter[1]} />
-  </label>
-  <label>
-    Zoom
-    <input type="number" class="input" bind:value={newZoom} />
-  </label>
-</div>
+  <div class="flex gap-4">
+    <button class="btn variant-filled mb-4" type="button" on:click={toggle}> Toggle </button>
 
-<button class="btn variant-filled mb-4 mt-2" type="button" on:click={apply}
-  >Apply new Coordinates</button
->
+    <button class="btn variant-filled mb-4" type="button" on:click={quickToggle}>
+      Toggle and Back
+    </button>
+  </div>
+  <div>
+    {currentCoords[0].toFixed(3)}, {currentCoords[1].toFixed(3)} @ {currentZoom}, {currentBearing}/{currentPitch}
+  </div>
+</div>
 
 <MapLibre
   style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
   class="relative aspect-[9/16] max-h-[70vh] w-full sm:aspect-video sm:max-h-full"
-  bind:center
-  bind:zoom
+  on:moveend={handleMoveEnd}
+  {bearing}
+  {pitch}
+  {center}
+  {zoom}
   standardControls
 ></MapLibre>
 

--- a/src/routes/tests/change_center_zoom/+page.svelte
+++ b/src/routes/tests/change_center_zoom/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { LngLatLike } from 'maplibre-gl';
+  import MapLibre from '$lib/MapLibre.svelte';
+  import CodeSample from '$site/CodeSample.svelte';
+  import code from './+page.svelte?raw';
+
+  let center: LngLatLike = [0, 0];
+  let zoom = 2;
+
+  let newZoom = zoom;
+  let newCenter = center;
+
+  function apply() {
+    center = newCenter;
+    zoom = newZoom;
+  }
+</script>
+
+<div class="flex gap-4">
+  <label>
+    Longitude
+    <input type="number" class="input" bind:value={newCenter[0]} />
+  </label>
+  <label>
+    Latitude
+    <input type="number" class="input" bind:value={newCenter[1]} />
+  </label>
+  <label>
+    Zoom
+    <input type="number" class="input" bind:value={newZoom} />
+  </label>
+</div>
+
+<button class="btn variant-filled mb-4 mt-2" type="button" on:click={apply}
+  >Apply new Coordinates</button
+>
+
+<MapLibre
+  style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+  class="relative aspect-[9/16] max-h-[70vh] w-full sm:aspect-video sm:max-h-full"
+  bind:center
+  bind:zoom
+  standardControls
+></MapLibre>
+
+<CodeSample {code} />

--- a/src/routes/tests/change_center_zoom/+page.ts
+++ b/src/routes/tests/change_center_zoom/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = () => {
+  return {
+    title: 'Change center and zoom',
+  };
+};


### PR DESCRIPTION
<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->
Makes sure that simultaneous changes to center and zoom work properly. This also handles external changes in `pitch` and `bearing`.

This adds a new internal test which tests simultaneously changing all the map viewport controls, and also quickly toggling between two settings.

Closes #168

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
