### PR TITLE
fix(Popup): `features`/`data` passed to slot always null

### DIFF
--- a/src/routes/examples/clusters/+page.svelte
+++ b/src/routes/examples/clusters/+page.svelte
@@ -71,8 +71,8 @@
       manageHoverState
       on:click={(e) => (clickedFeature = e.detail.features?.[0]?.properties)}
     >
-      <Popup {openOn} closeOnClickInside let:features>
-        <ClusterPopup feature={features?.[0]} />
+      <Popup {openOn} closeOnClickInside let:data>
+        <ClusterPopup feature={data ?? undefined} />
       </Popup>
     </CircleLayer>
 
@@ -113,17 +113,19 @@
       }}
       on:click={(e) => (clickedFeature = e.detail.features?.[0]?.properties)}
     >
-      <Popup {openOn} closeOnClickInside let:features>
-        {@const props = features?.[0]?.properties}
-        <p>
-          Date: <span class="font-medium text-gray-800"
-            >{new Date(props.time).toLocaleDateString()}</span
-          >
-        </p>
-        <p>Magnitude: <span class="font-medium text-gray-800">{props.mag}</span></p>
-        <p>
-          Tsunami: <span class="font-medium text-gray-800">{props.tsunami ? 'Yes' : 'No'}</span>
-        </p>
+      <Popup {openOn} closeOnClickInside let:data>
+        {@const props = data?.properties}
+        {#if props}
+          <p>
+            Date: <span class="font-medium text-gray-800"
+              >{new Date(props.time).toLocaleDateString()}</span
+            >
+          </p>
+          <p>Magnitude: <span class="font-medium text-gray-800">{props.mag}</span></p>
+          <p>
+            Tsunami: <span class="font-medium text-gray-800">{props.tsunami ? 'Yes' : 'No'}</span>
+          </p>
+        {/if}
       </Popup>
     </CircleLayer>
   </GeoJSON>

--- a/src/routes/examples/geojson_extrusion/+page.svelte
+++ b/src/routes/examples/geojson_extrusion/+page.svelte
@@ -40,11 +40,14 @@
       }}
       beforeLayerType="symbol"
     >
-      <Popup openOn="hover" let:features>
-        <div class="flex flex-col gap-2">
-          <div class="text-lg font-bold">{features[0].properties.NAME}</div>
-          <p>Population: {features[0].properties.POPESTIMATE2020}</p>
-        </div>
+      <Popup openOn="hover" let:data>
+        {@const props = data?.properties}
+        {#if props}
+          <div class="flex flex-col gap-2">
+            <div class="text-lg font-bold">{props.NAME}</div>
+            <p>Population: {props.POPESTIMATE2020}</p>
+          </div>
+        {/if}
       </Popup>
     </FillExtrusionLayer>
   </GeoJSON>

--- a/src/routes/examples/overlapping_layer_events/+page.svelte
+++ b/src/routes/examples/overlapping_layer_events/+page.svelte
@@ -111,7 +111,7 @@
       >
         <Popup {openOn} {openIfTopMost} let:features>
           <div style:background={color} style:color="white">
-            <p>{features.length} features from {color} layer</p>
+            <p>{features?.length} features from {color} layer</p>
             {#if color == 'red'}
               <p>extra padding for lowest red layer</p>
               <p>extra padding for lowest red layer</p>


### PR DESCRIPTION
fixes #183

It looks like `null` is used more often than `undefined` elsewhere in this package, so I've standardized both `features` and `data` to `T | null`. I'd probably prefer `undefined`, but feel this is better at the moment for consistency. 