### PR TITLE
Add label attribute to ControlButton

### DIFF
--- a/src/lib/ControlButton.svelte
+++ b/src/lib/ControlButton.svelte
@@ -4,11 +4,12 @@
    * @default true since most map buttons are icons. */
   export let icon = true;
   export let center = true;
+  export let label = "";
   let classNames: string | undefined = undefined;
   export { classNames as class };
 </script>
 
-<button type="button" on:click>
+<button type="button" title={label} on:click>
   <div class:maplibregl-ctrl-icon={icon} class:ctrl-btn-center={center} class={classNames}>
     <slot />
   </div>


### PR DESCRIPTION
The `label` attribute will set the `title` property on the `<button>` element, which is important for accessibility and UX.