### PR TITLE
Defer updating Layer’s layout and paint properties until Map style is fully loaded

### DIFF
--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -280,7 +280,7 @@
 
   $: applyPaint = $layer
     ? diffApplier((key, value) => {
-        if ($map?.isStyleLoaded()) {
+        if ($map?.style._loaded) {
           $map.setPaintProperty($layer!, key, value);
         } else {
           $map?.once('styledata', () => $map?.setPaintProperty($layer!, key, value));
@@ -290,7 +290,7 @@
 
   $: applyLayout = $layer
     ? diffApplier((key, value) => {
-        if ($map?.isStyleLoaded()) {
+        if ($map?.style._loaded) {
           $map.setLayoutProperty($layer!, key, value);
         } else {
           $map?.once('styledata', () => $map?.setLayoutProperty($layer!, key, value));

--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -279,14 +279,28 @@
   });
 
   $: applyPaint = $layer
-    ? diffApplier((key, value) => $map?.setPaintProperty($layer!, key, value))
-    : undefined;
+    ? diffApplier((key, value) => {
+        if ($map?.isStyleLoaded()) {
+          $map.setPaintProperty($layer!, key, value);
+        } else {
+          $map?.once('styledata', () => $map?.setPaintProperty($layer!, key, value));
+        }
+      })
+    : void 0;
+
   $: applyLayout = $layer
-    ? diffApplier((key, value) => $map?.setLayoutProperty($layer!, key, value))
-    : undefined;
+    ? diffApplier((key, value) => {
+        if ($map?.isStyleLoaded()) {
+          $map.setLayoutProperty($layer!, key, value);
+        } else {
+          $map?.once('styledata', () => $map?.setLayoutProperty($layer!, key, value));
+        }
+      })
+    : void 0;
 
   $: applyPaint?.(paint);
   $: applyLayout?.(layout);
+
   $: if ($layer) $map?.setLayerZoomRange($layer, actualMinZoom, actualMaxZoom);
 
   // Don't set the filter again after we've just created it.


### PR DESCRIPTION
When both the MapLibre's `style` and Layer properties are modified almost simultaneously, the following error occurs:

```
style.ts:556 Uncaught (in promise) Error: Style is not done loading.
    at de._checkLoaded (style.ts:556:19)
    at de.setLayoutProperty (style.ts:1148:14)
    at t.Map.setLayoutProperty (map.ts:2603:20)
    at Layer.svelte:221:39
    at compare.js:9:21
    at $$self.$$.update (Layer.svelte:225:5)
    at update (scheduler.js:115:6)
    at flush (scheduler.js:79:5)
```

This PR modifies the code to check `isStyleLoaded()`, and if the style is still loading, it delays the `setLayoutProperty` and `setPaintProperty`.

![image](https://github.com/user-attachments/assets/8c6c204a-d4a5-4d74-8cb5-4716f0671b3b)
