### PR TITLE
fix: FullscreenControl component

### DIFF
--- a/.changeset/light-meals-agree.md
+++ b/.changeset/light-meals-agree.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Fix FullscreenControl component (containerElement is not mandatory and defaults to map container)

--- a/src/lib/FullscreenControl.svelte
+++ b/src/lib/FullscreenControl.svelte
@@ -23,10 +23,14 @@
   });
 
   $effect(() => {
-    if (containerEl && !control) {
-      control = new maplibregl.FullscreenControl({
-        container: containerEl,
-      });
+    if (!control) {
+      if (containerEl) {
+        control = new maplibregl.FullscreenControl({
+          container: containerEl,
+        });
+      } else {
+        control = new maplibregl.FullscreenControl();
+      }
       map.addControl(control, position);
     }
   });


### PR DESCRIPTION
fixes #231

`maplibregl.FullscreenControl` can be created without specifying a container element (defaulting to the map instance HTML wrapper element)

ref: [https://github.com/maplibre/maplibre-gl-js/blob/47ed30d6ec105cbfb8768fd27da1b317af31b903/src/ui/control/fullscreen_control.ts\#L78](https://github.com/maplibre/maplibre-gl-js/blob/47ed30d6ec105cbfb8768fd27da1b317af31b903/src/ui/control/fullscreen_control.ts#L78)

<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->
