### PR TITLE
Exposed `bearingSnap` property via MapLibre.svelte properties

### DIFF
--- a/.changeset/brave-jeans-train.md
+++ b/.changeset/brave-jeans-train.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': minor
+---
+
+Exposed the bearingSnap property in the maps props to allow control over the default automatic snap-to-north

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -34,6 +34,7 @@
     zoom?: number | undefined;
     pitch?: number;
     bearing?: number;
+    bearingSnap?: number;
     bounds?: LngLatBoundsLike | undefined;
     /** Set to true to track the map viewport in the URL hash. If the URL hash is set, that overrides initial viewport settings. */
     hash?: boolean;
@@ -111,6 +112,7 @@
     zoom = $bindable(undefined),
     pitch = $bindable(0),
     bearing = $bindable(0),
+    bearingSnap = 7,
     bounds = $bindable(undefined),
     hash = false,
     updateHash = (url) => {
@@ -247,6 +249,7 @@
         zoom,
         pitch,
         bearing,
+        bearingSnap,
         minZoom,
         maxZoom,
         minPitch,


### PR DESCRIPTION
Added a `bearingSnap` property to the MapLibre.svelte props to allow the user to control the behaviour of the automatic 'snap-to-north' in maplibregl.

The default value is set to `7` as per the original [maplibre source](https://github.com/maplibre/maplibre-gl-js/blob/ef74795676d4e6a7c3b89b52a1ff068fa2ad5955/src/ui/map.ts#L387)

Fixes #243 

 