### PR TITLE
Popups inherit lnglat

### DIFF
--- a/.changeset/wild-donkeys-chew.md
+++ b/.changeset/wild-donkeys-chew.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': minor
+---
+
+Allow Popups to inherit lngLat from a parent Marker

--- a/src/lib/DefaultMarker.svelte
+++ b/src/lib/DefaultMarker.svelte
@@ -2,13 +2,7 @@
   import maplibre, { type LngLatLike, type PointLike } from 'maplibre-gl';
   import { onDestroy } from 'svelte';
   import type { Snippet } from 'svelte';
-  import {
-    Box,
-    Box,
-    getMapContext,
-    setLngLatContext,
-    updatedMarkerContext,
-  } from './context.svelte.js';
+  import { Box, getMapContext, setLngLatContext, updatedMarkerContext } from './context.svelte.js';
   import type { MarkerClickInfo } from './types';
   import type { Feature, Point } from 'geojson';
   import { flush } from '$lib/flush.js';

--- a/src/lib/DefaultMarker.svelte
+++ b/src/lib/DefaultMarker.svelte
@@ -2,7 +2,13 @@
   import maplibre, { type LngLatLike, type PointLike } from 'maplibre-gl';
   import { onDestroy } from 'svelte';
   import type { Snippet } from 'svelte';
-  import { getMapContext, updatedMarkerContext } from './context.svelte.js';
+  import {
+    Box,
+    Box,
+    getMapContext,
+    setLngLatContext,
+    updatedMarkerContext,
+  } from './context.svelte.js';
   import type { MarkerClickInfo } from './types';
   import type { Feature, Point } from 'geojson';
   import { flush } from '$lib/flush.js';
@@ -88,8 +94,12 @@
     marker.value?.remove();
   });
 
+  let lngLatBox = new Box(lngLat);
+  setLngLatContext(lngLatBox);
+
   $effect(() => {
     marker.value?.setLngLat(lngLat);
+    lngLatBox.value = lngLat;
   });
   $effect(() => {
     if (offset) {

--- a/src/lib/Marker.svelte
+++ b/src/lib/Marker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" generics="FEATURE extends Feature = Feature">
   import maplibre, { type LngLatLike, type PointLike } from 'maplibre-gl';
   import type { Snippet } from 'svelte';
-  import { getMapContext, updatedMarkerContext } from './context.svelte.js';
+  import { Box, getMapContext, setLngLatContext, updatedMarkerContext } from './context.svelte.js';
   import type {
     MarkerClickInfo,
     MarkerClickInfoFeature as GenMarkerClickInfoFeature,
@@ -126,8 +126,12 @@
     };
   }
 
+  let lngLatBox = new Box(lngLat);
+  setLngLatContext(lngLatBox);
+
   $effect(() => {
     marker.value?.setLngLat(lngLat);
+    lngLatBox.value = lngLat;
   });
   $effect(() => {
     if (offset) {

--- a/src/lib/Popup.svelte
+++ b/src/lib/Popup.svelte
@@ -13,6 +13,7 @@
     getLayer,
     getLayerEvent,
     getPopupTarget,
+    getLngLatContext,
   } from './context.svelte.js';
   import type { MarkerClickInfo } from './types.js';
 
@@ -41,7 +42,8 @@
     lngLat?: maplibregl.LngLatLike;
     /** If set and the slot is omitted, use this string as HTML to pass into the popup. */
     html?: string;
-    /** Whether the popup is open or not. Can be set to manualy open the popup at `lngLat`. */
+    /** Whether the popup is open or not. Can be set to manually open the popup at `lngLat`,
+     * if openOn is not `hover`. */
     open?: boolean;
     children?: Snippet<
       [
@@ -85,6 +87,8 @@
     onclose = undefined,
     onhover = undefined,
   }: Props = $props();
+
+  let inheritedLngLat = getLngLatContext();
 
   const { map, eventTopMost, markerClickManager, loaded } = $derived(getMapContext());
   const layer = getLayer();
@@ -402,7 +406,8 @@
   });
 
   $effect(() => {
-    if (lngLat) popup?.setLngLat(lngLat);
+    let actualLnglat = lngLat ?? inheritedLngLat?.value ?? undefined;
+    if (actualLnglat) popup?.setLngLat(actualLnglat);
   });
 
   $effect(() => {

--- a/src/lib/context.svelte.ts
+++ b/src/lib/context.svelte.ts
@@ -1,4 +1,4 @@
-import type { Map as MapLibre, MapMouseEvent, Marker } from 'maplibre-gl';
+import type { LngLatLike, Map as MapLibre, MapMouseEvent, Marker } from 'maplibre-gl';
 import { getContext, setContext } from 'svelte';
 import { SvelteSet } from 'svelte/reactivity';
 import type { ClusterOptions, MarkerClickInfo } from './types';
@@ -136,6 +136,14 @@ export function setLayerEvent(value: Box<LayerEvent | undefined>) {
   setContext(LAYER_EVENT_KEY, value);
 }
 
+export function setLngLatContext(value: Box<LngLatLike | undefined>) {
+  setContext(LNG_LAT_KEY, value);
+}
+
+export function getLngLatContext(): Box<LngLatLike | undefined> | undefined {
+  return getContext(LNG_LAT_KEY);
+}
+
 export type MarkerMouseEvent = MarkerClickInfo & { layerType: 'marker'; type: string };
 
 export interface DeckGlMouseEvent<DATA = unknown> extends PickingInfo<DATA> {
@@ -152,6 +160,7 @@ const SOURCE_KEY = Symbol.for('svelte-maplibre.source');
 const CLUSTER_KEY = Symbol.for('svelte-maplibre.cluster');
 const ZOOM_KEY = Symbol.for('svelte-maplibre.zoom');
 const LAYER_EVENT_KEY = Symbol.for('svelte-maplibre.layer-event');
+const LNG_LAT_KEY = Symbol.for('svelte-maplibre.lng-lat');
 
 export function getMapContext(): MapContext {
   return getContext(MAP_CONTEXT_KEY);

--- a/src/routes/examples/custom_marker/+page.svelte
+++ b/src/routes/examples/custom_marker/+page.svelte
@@ -44,6 +44,18 @@
       name: 'Ninoy Aquino',
     },
   ];
+
+  let open = $state(markers.map(() => false));
+
+  let buttonAction = $derived(open.some((v) => v === false) ? 'open' : 'close');
+
+  function toggleAll() {
+    if (buttonAction === 'open') {
+      open = open.map(() => true);
+    } else {
+      open = open.map(() => false);
+    }
+  }
 </script>
 
 <p>
@@ -54,6 +66,10 @@
   {/if}
 </p>
 
+<button type="button" class="btn-base" onclick={toggleAll}>
+  {buttonAction === 'open' ? 'Open All' : 'Close All'} Popups
+</button>
+
 <MapLibre
   style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
   class={mapClasses}
@@ -61,7 +77,7 @@
   zoom={1}
   center={[-20, 0]}
 >
-  {#each markers as { lngLat, label, name } (label)}
+  {#each markers as { lngLat, label, name }, i (label)}
     <Marker
       {lngLat}
       onclick={() => (clickedName = name)}
@@ -71,7 +87,7 @@
         {label}
       </span>
 
-      <Popup openOn="hover" offset={[0, -10]}>
+      <Popup openOn="click" bind:open={open[i]} offset={[0, -10]}>
         <div class="text-lg font-bold">{name}</div>
       </Popup>
     </Marker>


### PR DESCRIPTION
Fixes #239. This allows Popups to inherit their lngLat from a parent Marker component so that they can be programmatically triggered without needing to re-specify the lngLat property on the Marker itself.
