### PR TITLE
Fix type name conflicts with Maplibre types

### DIFF
--- a/.changeset/sweet-flies-develop.md
+++ b/.changeset/sweet-flies-develop.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Fix type name conflicts with Maplibre types

--- a/src/lib/ImageSource.svelte
+++ b/src/lib/ImageSource.svelte
@@ -3,7 +3,7 @@
   import type { Snippet } from 'svelte';
   import { getId, getMapContext, updatedSourceContext } from './context.svelte.js';
   import { addSource, removeSource } from './source.js';
-  import type { ImageSource, Coordinates } from 'maplibre-gl';
+  import type { ImageSource as MaplibreImageSource, Coordinates } from 'maplibre-gl';
   import { flush } from '$lib/flush.js';
 
   interface Props {
@@ -17,7 +17,7 @@
 
   const { map } = $derived(getMapContext());
   const { source } = updatedSourceContext();
-  let sourceObj: ImageSource | undefined = $state();
+  let sourceObj: MaplibreImageSource | undefined = $state();
 
   let first = $state(true);
   $effect(() => {
@@ -36,7 +36,7 @@
           if (!source.value) {
             return;
           }
-          sourceObj = map.getSource(source.value) as ImageSource;
+          sourceObj = map.getSource(source.value) as MaplibreImageSource;
           first = true;
         }
       );
@@ -58,7 +58,7 @@
     map.on('style.load', () => {
       // When the style changes the current sources are nuked and recreated. Because of this the
       // source object no longer references the current source on the map so we update it here.
-      sourceObj = map.getSource(id) as ImageSource | undefined;
+      sourceObj = map.getSource(id) as MaplibreImageSource | undefined;
     });
   });
 

--- a/src/lib/RasterDEMTileSource.svelte
+++ b/src/lib/RasterDEMTileSource.svelte
@@ -4,7 +4,10 @@
   import { getId, getMapContext, updatedSourceContext } from './context.svelte.js';
   import { addSource, removeSource } from './source.js';
   import { flush } from '$lib/flush.js';
-  import type { DEMEncoding, RasterDEMTileSource } from 'maplibre-gl';
+  import type {
+    DEMEncoding,
+    RasterDEMTileSource as MaplibreRasterDEMTileSource,
+  } from 'maplibre-gl';
 
   interface Props {
     id?: string;
@@ -42,7 +45,7 @@
 
   const { map } = $derived(getMapContext());
   const { source } = updatedSourceContext();
-  let sourceObj: RasterDEMTileSource | undefined = $state();
+  let sourceObj: MaplibreRasterDEMTileSource | undefined = $state();
 
   let first = $state(true);
   $effect(() => {
@@ -72,7 +75,7 @@
             return;
           }
 
-          sourceObj = map.getSource(source.value) as RasterDEMTileSource;
+          sourceObj = map.getSource(source.value) as MaplibreRasterDEMTileSource;
           first = true;
         }
       );
@@ -96,7 +99,7 @@
     map.on('style.load', () => {
       // When the style changes the current sources are nuked and recreated. Because of this the
       // source object no longer references the current source on the map so we update it here.
-      sourceObj = map.getSource(id) as RasterDEMTileSource | undefined;
+      sourceObj = map.getSource(id) as MaplibreRasterDEMTileSource | undefined;
     });
   });
 

--- a/src/lib/RasterTileSource.svelte
+++ b/src/lib/RasterTileSource.svelte
@@ -6,7 +6,7 @@
   import type { Scheme } from './types.js';
   import { flush } from '$lib/flush.js';
   import * as pmtiles from 'pmtiles';
-  import maplibregl, { type RasterTileSource } from 'maplibre-gl';
+  import maplibregl, { type RasterTileSource as MaplibreRasterTileSource } from 'maplibre-gl';
 
   interface Props {
     id?: string;
@@ -48,7 +48,7 @@
 
   const { map } = $derived(getMapContext());
   const { source } = updatedSourceContext();
-  let sourceObj: RasterTileSource | undefined = $state();
+  let sourceObj: MaplibreRasterTileSource | undefined = $state();
 
   let first = $state(true);
   $effect(() => {
@@ -75,7 +75,7 @@
             return;
           }
 
-          sourceObj = map.getSource(source.value) as RasterTileSource;
+          sourceObj = map.getSource(source.value) as MaplibreRasterTileSource;
           first = true;
         }
       );
@@ -100,7 +100,7 @@
     map.on('style.load', () => {
       // When the style changes the current sources are nuked and recreated. Because of this the
       // source object no longer references the current source on the map so we update it here.
-      sourceObj = map.getSource(id) as RasterTileSource | undefined;
+      sourceObj = map.getSource(id) as MaplibreRasterTileSource | undefined;
     });
   });
 


### PR DESCRIPTION
Follow-up to #222.

### Scope

- Use internal type name aliases for Maplibre's `ImageSource`, `RasterDEMTileSource` and `RasterTileSource` to prevent import errors for the corresponding components

### Out of scope

- The `GeoJSON` component is also importing a type of the same name, but for some reason it doesn't cause an import error. I've left it unmodified for now.