### PR TITLE
feat(Popup): pass isOpen to prop to children

### DIFF
--- a/.changeset/moody-lemons-boil.md
+++ b/.changeset/moody-lemons-boil.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': minor
+---
+
+pass isOpen to Popup children to prevent rendering Popup content before shown

--- a/src/lib/Popup.svelte
+++ b/src/lib/Popup.svelte
@@ -52,6 +52,7 @@
           data: DATA | undefined;
           map: maplibregl.Map | undefined;
           close: () => void;
+          isOpen: boolean;
         },
       ]
     >;
@@ -433,6 +434,7 @@
         data: features?.[0] ?? undefined,
         map: map,
         close: () => (open = false),
+        isOpen: open,
       })}
     {/if}
   </div>


### PR DESCRIPTION
<!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
`npm run changeset`. -->
Passes an `isOpen` prop to `Popup`'s children to allow for the content to not be rendered until the Popup is opened. Particularly useful when you don't wish to load async content before showing the popup, but don't want to create a whole separate wrapper component.