### PR TITLE
Fix crash in hash parsing

### DIFF
--- a/.changeset/open-clouds-fly.md
+++ b/.changeset/open-clouds-fly.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Fix crash in hash parsing

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -24,5 +24,6 @@ export function getViewportHash(map: Map): string {
 
 // Returns [zoom, center lat, center lng, optionally bearing, optionally pitch]
 export function parseViewportHash(hash: string): number[] {
-  return hash.replace('#', '').split('/').map(parseFloat);
+  const parts = hash.replace('#', '').split('/').map(parseFloat);
+  return parts.some(isNaN) ? [] : parts;
 }


### PR DESCRIPTION
Test by going to http://localhost:5173/examples/geojson_line_layer##5/43.43/-62.29 -- note the double #. Before, this crashes, and after, it just ignores the whole hash. The double hash sometimes happens when copy-pasting bits of a URL quickly.