### PR TITLE
Fix bug where a destroyed Layer kept the onclick handler

### DIFF
--- a/.changeset/vast-showers-fix.md
+++ b/.changeset/vast-showers-fix.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+Fix bug where a destroyed Layer kept the onclick handler

--- a/src/lib/Layer.svelte
+++ b/src/lib/Layer.svelte
@@ -210,6 +210,7 @@
   let first = $state(true);
 
   function unsubEvents(layerName: string) {
+    map.off('click', layerName, handleClick);
     map.off('dblclick', layerName, handleClick);
     map.off('contextmenu', layerName, handleClick);
     map.off('mouseenter', layerName, handleMouseEnter);


### PR DESCRIPTION
This was a tricky one! I have a component with a `<LineLayer onclick...>`. After it was destroyed and recreated with a different onclick handler, the old handler was still being called!
