### PR TITLE
fix: handle maplibre GPUInitializationError when constructing new map

### DIFF
--- a/.changeset/big-views-flow.md
+++ b/.changeset/big-views-flow.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+fix: check if webgl is enabled and call onerror otherwise

--- a/.changeset/big-views-flow.md
+++ b/.changeset/big-views-flow.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre': patch
+---
+
+fix: handle maplibre GPUInitializationError when constructing new map

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "d3-geo": "^3.1.0",
     "dequal": "^2.0.3",
     "just-compare": "^2.3.0",
-    "maplibre-gl": "^6.0.0",
+    "maplibre-gl": "^6.7.0",
     "pmtiles": "^3.0.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       maplibre-gl:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.7.0
+        version: 6.7.0
       pmtiles:
         specifier: ^3.0.3
         version: 3.2.1
@@ -636,12 +636,12 @@ packages:
   '@maplibre/geojson-vt@6.1.1':
     resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@26.2.1':
-    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
+  '@maplibre/maplibre-gl-style-spec@26.4.1':
+    resolution: {integrity: sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==}
     hasBin: true
 
-  '@maplibre/mlt@1.1.12':
-    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+  '@maplibre/mlt@1.2.1':
+    resolution: {integrity: sha512-5n5dgolE2EYxwCKgx8vlwURCB8A+kyfJJyThlYimjlGgOcOe2Bhw9VxxnnHC91OC9PgHg+nVdgVPTYPkIo62vg==}
 
   '@maplibre/vt-pbf@4.3.2':
     resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
@@ -1893,8 +1893,8 @@ packages:
   mapbox-gl@3.16.0:
     resolution: {integrity: sha512-rluV1Zp/0oHf1Y9BV+nePRNnKyTdljko3E19CzO5rBqtQaNUYS0ePCMPRtxOuWRwSdKp3f9NWJkOCjemM8nmjw==}
 
-  maplibre-gl@6.0.0:
-    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
+  maplibre-gl@6.7.0:
+    resolution: {integrity: sha512-Y1Q1+UP9WXou0DUrnaFdDsoMqiMCWy6aS968IBUaQ2eZi6H1/kPCfpfZOWXFJZbeKMkX9Wo6OFzY/k48qqPf3Q==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   martinez-polygon-clipping@0.7.4:
@@ -3217,7 +3217,7 @@ snapshots:
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@26.2.1':
+  '@maplibre/maplibre-gl-style-spec@26.4.1':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 1.0.0
@@ -3226,7 +3226,7 @@ snapshots:
       quickselect: 3.0.0
       tinyqueue: 3.0.0
 
-  '@maplibre/mlt@1.1.12':
+  '@maplibre/mlt@1.2.1':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
 
@@ -4424,15 +4424,15 @@ snapshots:
       supercluster: 8.0.1
       tinyqueue: 3.0.0
 
-  maplibre-gl@6.0.0:
+  maplibre-gl@6.7.0:
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
       '@mapbox/unitbezier': 1.0.0
       '@mapbox/vector-tile': 3.0.0
       '@maplibre/geojson-vt': 6.1.1
-      '@maplibre/maplibre-gl-style-spec': 26.2.1
-      '@maplibre/mlt': 1.1.12
+      '@maplibre/maplibre-gl-style-spec': 26.4.1
+      '@maplibre/mlt': 1.2.1
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
       earcut: 3.2.3

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -253,8 +253,29 @@
     }
   }
 
+  function isWebglSupported() {
+    if (!window.WebGLRenderingContext) {
+      return false;
+    }
+    const canvas = document.createElement('canvas');
+    try {
+      const context = canvas.getContext('webgl2') || canvas.getContext('webgl');
+      if (context && typeof context.getParameter == 'function') {
+        return true;
+      }
+    } catch (e) {
+      // WebGL is supported, but disabled
+    }
+    return false;
+  }
+
   function createMap(element: HTMLDivElement) {
     onHashChange();
+
+    if (!isWebglSupported()) {
+      handleError(new ErrorEvent('', { error: new Error('WebGL is disabled or not supported') }));
+      return;
+    }
 
     map = mapContext.map = new maplibre.Map(
       flush({
@@ -282,7 +303,7 @@
         attributionControl,
         transformRequest,
         cooperativeGestures,
-        aroundCenter
+        aroundCenter,
       })
     );
 

--- a/src/lib/MapLibre.svelte
+++ b/src/lib/MapLibre.svelte
@@ -263,40 +263,49 @@
   function createMap(element: HTMLDivElement) {
     onHashChange();
 
-    map = mapContext.map = new maplibregl.Map({
-      ...flush({
-        container: element,
-        style,
-        locale,
-        center,
-        zoom,
-        pitch,
-        bearing,
-        bearingSnap,
-        minZoom,
-        maxZoom,
-        minPitch,
-        maxPitch,
-        renderWorldCopies,
-        dragPan,
-        dragRotate,
-        pitchWithRotate,
-        antialias,
-        interactive,
-        preserveDrawingBuffer,
-        maxBounds,
-        bounds,
-        attributionControl,
-        transformRequest,
-        cooperativeGestures,
-        aroundCenter,
-      }),
-      // MapLibre tells "absent" (overscale 4 levels) apart from an explicit `undefined`
-      // (overscale everything), and `flush` drops both, so this is applied outside it.
-      ...(zoomLevelsToOverscale === undefined
-        ? {}
-        : { zoomLevelsToOverscale: zoomLevelsToOverscale ?? undefined }),
-    });
+    try {
+      map = mapContext.map = new maplibregl.Map({
+        ...flush({
+          container: element,
+          style,
+          locale,
+          center,
+          zoom,
+          pitch,
+          bearing,
+          bearingSnap,
+          minZoom,
+          maxZoom,
+          minPitch,
+          maxPitch,
+          renderWorldCopies,
+          dragPan,
+          dragRotate,
+          pitchWithRotate,
+          antialias,
+          interactive,
+          preserveDrawingBuffer,
+          maxBounds,
+          bounds,
+          attributionControl,
+          transformRequest,
+          cooperativeGestures,
+          aroundCenter,
+        }),
+        // MapLibre tells "absent" (overscale 4 levels) apart from an explicit `undefined`
+        // (overscale everything), and `flush` drops both, so this is applied outside it.
+        ...(zoomLevelsToOverscale === undefined
+          ? {}
+          : { zoomLevelsToOverscale: zoomLevelsToOverscale ?? undefined }),
+      });
+    } catch (e) {
+      // This is the only error we expect the constructor to throw
+      if (e instanceof maplibregl.GPUInitializationError) {
+        handleError(new ErrorEvent('GPUInitializationError', { error: e }));
+        return;
+      }
+      throw e;
+    }
 
     map.on('load', (e) => {
       e.target.getContainer().setAttribute('data-testid', 'map');

--- a/src/routes/examples/basic/+page.svelte
+++ b/src/routes/examples/basic/+page.svelte
@@ -16,7 +16,7 @@
 
 <MapLibre
   style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
-  class="relative aspect-[9/16] max-h-[70vh] w-full sm:aspect-video sm:max-h-full"
+  class="relative aspect-9/16 max-h-[70vh] w-full sm:aspect-video sm:max-h-full"
   standardControls
   bind:bounds
 />


### PR DESCRIPTION
Fixes #279 by handling the `GPUInitializationError` maplibre throws. Requires updating to v6.7.0

~As reported in the bug, the svelte app can completely freeze when webgl is disabled, and a MapLibre component is created without a `<svelte:boundary>` to contain errors. It's better to just check it ourselves, and report errors to the consumer via the `onerror` callback.~

~`isWebglSupported` is basically a copy from https://maplibre.org/maplibre-gl-js/docs/examples/check-if-webgl-is-supported/~