### PR TITLE
Add GitHub issue templates and improve PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Report a problem with svelte-maplibre
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report! A clear description and a
+        minimal reproduction are by far the most useful things you can provide.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: >-
+        What did you expect to happen, and what actually happened? Describe the
+        actual symptoms you observe in as much concrete detail as you can —
+        error messages, what renders (or doesn't), console output, etc.
+      placeholder: When I add a <Marker>, it renders at the wrong coordinates and the console logs ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: >-
+        A link to a minimal reproduction (StackBlitz, a small repo, or a REPL)
+        or a self-contained code snippet that demonstrates the problem. Please
+        strip out everything not needed to reproduce it — the smaller the
+        example, the faster this can be fixed.
+      placeholder: https://stackblitz.com/edit/... or a short code snippet
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: svelte-maplibre version
+      description: Which version of svelte-maplibre are you using?
+      placeholder: e.g. 1.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Svelte / SvelteKit version and environment
+      description: >-
+        Relevant versions (Svelte, SvelteKit, maplibre-gl) and your
+        environment (browser, OS, SSR vs. client-only) if applicable.
+      placeholder: e.g. Svelte 5.0.0, SvelteKit 2.0.0, maplibre-gl 4.0.0, Chrome on macOS
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ### A note on AI-generated diagnoses
+
+        Please **don't** paste an AI assistant's explanation of *why* the code
+        is broken in place of describing the problem. These explanations are
+        very often misleading — they sound plausible and confident but point at
+        the wrong cause, which sends everyone down the wrong path and makes the
+        bug *harder* to fix.
+
+        If you don't fully understand the cause yourself, that's completely
+        fine! It is far more helpful to describe the **actual symptoms** in
+        detail — what you did, what you saw, the exact errors — than to include
+        a guess at the root cause. By all means use AI to help build a clean
+        minimal reproduction.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: >-
+            I have described the actual symptoms I observe rather than pasting
+            an AI-generated guess at the root cause.
+          required: true
+        - label: I have included a minimal reproduction or a self-contained code snippet.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussion
+    url: https://github.com/dimfeld/svelte-maplibre/discussions
+    about: For usage questions and general discussion, please open a discussion instead of an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest an idea or enhancement for svelte-maplibre
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: >-
+        Describe the use case or the limitation you're running into. Focus on
+        the concrete thing you're trying to do, not just a proposed API.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like svelte-maplibre to do? An example of how you'd use it is helpful.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you're using today, or other approaches you've thought about.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,30 @@
 <!-- If you haven't already, please add a changeset for this pull request. You can do this by running `pnpm changeset` or
 `npm run changeset`. -->
+
+## Description
+
+<!-- What does this PR do, and why? Link any related issues. -->
+
+## AI usage
+
+<!-- Please be honest here — it's genuinely helpful for review, not a judgement. -->
+
+How much of this PR was written or assisted by AI tools (e.g. none, minor edits, mostly AI-generated)?
+
+<!-- Describe what was AI-assisted: -->
+
+**What did you, the human submitter, do to manually check and understand the code?**
+
+<!--
+For example: ran it locally and observed the behavior, read through every line and can explain
+what it does, wrote or ran tests, verified the reproduction from the issue is fixed, etc.
+
+If a change was largely AI-generated, please confirm you understand it well enough to maintain
+and explain it — AI output often looks correct but is subtly wrong.
+-->
+
+## Checklist
+
+- [ ] I have added a changeset (`pnpm changeset`) if this change affects the published package.
+- [ ] I have tested these changes manually and/or added/updated tests.
+- [ ] I understand the code in this PR and can explain what it does.


### PR DESCRIPTION
- Add bug report template asking for version and a minimal reproduction,
  and discouraging AI-generated root-cause diagnoses in favor of detailed
  symptom descriptions
- Add feature request template and issue template config
- Add AI-usage section to the PR template asking submitters to describe
  what they did to manually check and understand the code